### PR TITLE
Extract SPDX license JSON parsing to its own class

### DIFF
--- a/src/main/kotlin/app/cash/licensee/licensesSpdx.kt
+++ b/src/main/kotlin/app/cash/licensee/licensesSpdx.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.licensee
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+internal class SpdxLicenses(
+  private val identifierToLicense: Map<String, SpdxLicense>,
+  private val urlToLicense: Map<String, SpdxLicense>,
+) {
+  fun findByIdentifier(id: String) = identifierToLicense[id]
+  fun findByUrl(url: String) = urlToLicense[url]
+
+  companion object {
+    private const val spdxBaseUrl = "https://spdx.org/licenses/"
+    private val format = Json {
+      ignoreUnknownKeys = true
+    }
+
+    fun parseJson(json: String): SpdxLicenses {
+      val licenses = format.decodeFromString(SpdxLicensesJson.serializer(), json)
+
+      val identifierToLicense = licenses.licenses
+        .map { license ->
+          val firstUrl = license.otherUrls[0]
+          val targetUrl = if (firstUrl.startsWith("http://")) {
+            // Assume an 'https' variant is reachable.
+            "https" + firstUrl.substring(4)
+          } else {
+            firstUrl
+          }
+          SpdxLicense(license.id, license.name, targetUrl)
+        }
+        .associateBy { it.identifier }
+
+      val urlToLicense = licenses.licenses
+        .flatMap { license ->
+          val urls = mutableListOf<String>()
+
+          val spdxRelativeUrl = license.spdxUrl
+          check(spdxRelativeUrl.startsWith("./"))
+          val spdxUrl = spdxBaseUrl + spdxRelativeUrl.substring(2)
+          urls += spdxUrl
+
+          for (otherUrl in license.otherUrls) {
+            if (otherUrl.startsWith("http://")) {
+              // Assume an 'https' variant is reachable.
+              val httpsUrl = "https" + otherUrl.substring(4)
+              urls += httpsUrl
+            }
+            urls += otherUrl
+          }
+
+          urls.map { it to identifierToLicense.getValue(license.id) }
+        }
+        // TODO https://github.com/cashapp/licensee/issues/28
+        // Sort+distinct creates the behavior where we prefer the shortest identifier which maps to
+        // each URL. Take, for example, MPL-2.0 and MPL-2.0-no-copyleft-exception which use the same
+        // URL. For now, we'll blanket prefer the first.
+        .sortedBy { it.second.identifier.length }
+        .distinctBy { it.first }
+        .toMap()
+
+      return SpdxLicenses(
+        identifierToLicense,
+        urlToLicense,
+      )
+    }
+  }
+}
+
+@Serializable
+private data class SpdxLicensesJson(
+  val licenses: List<SpdxLicenseJson>,
+)
+
+@Serializable
+private data class SpdxLicenseJson(
+  @SerialName("licenseId") val id: String,
+  val name: String,
+  @SerialName("detailsUrl") val spdxUrl: String,
+  @SerialName("seeAlso") val otherUrls: List<String>,
+)

--- a/src/test/kotlin/app/cash/licensee/SpdxLicensesTest.kt
+++ b/src/test/kotlin/app/cash/licensee/SpdxLicensesTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.licensee
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SpdxLicensesTest {
+  @Test fun shortestIdentifierAlwaysPreferredRegardlessOfOrder() {
+    val json = """
+      |{"licenses":[
+      |  {
+      |    "licenseId": "FOO-1.0",
+      |    "name": "Foo License",
+      |    "detailsUrl": "./FOO-1.0.html",
+      |    "seeAlso": [
+      |      "http://example.com/foo"
+      |    ]
+      |  },
+      |  {
+      |    "licenseId": "FOO-1.0-some-variant",
+      |    "name": "Foo Variant License",
+      |    "detailsUrl": "./FOO-1.0-some-variant.html",
+      |    "seeAlso": [
+      |      "http://example.com/foo"
+      |    ]
+      |  },
+      |  {
+      |    "licenseId": "BAR-1.0-some-variant",
+      |    "name": "Bar Variant License",
+      |    "detailsUrl": "./BAR-1.0-some-variant.html",
+      |    "seeAlso": [
+      |      "http://example.com/bar"
+      |    ]
+      |  },
+      |  {
+      |    "licenseId": "BAR-1.0",
+      |    "name": "Bar License",
+      |    "detailsUrl": "./BAR-1.0.html",
+      |    "seeAlso": [
+      |      "http://example.com/bar"
+      |    ]
+      |  }
+      |]}
+      |""".trimMargin()
+    val spdxLicenses = SpdxLicenses.parseJson(json)
+    assertEquals(
+      SpdxLicense("FOO-1.0", "Foo License", "https://example.com/foo"),
+      spdxLicenses.findByUrl("http://example.com/foo")
+    )
+    assertEquals(
+      SpdxLicense("BAR-1.0", "Bar License", "https://example.com/bar"),
+      spdxLicenses.findByUrl("http://example.com/bar")
+    )
+  }
+
+  @Test fun httpUrlGetsHttpsVariant() {
+    val json = """
+      |{"licenses":[
+      |  {
+      |    "licenseId": "FOO-1.0",
+      |    "name": "Foo License",
+      |    "detailsUrl": "./FOO-1.0.html",
+      |    "seeAlso": [
+      |      "http://example.com/foo"
+      |    ]
+      |  },
+      |  {
+      |    "licenseId": "BAR-1.0",
+      |    "name": "Bar License",
+      |    "detailsUrl": "./BAR-1.0.html",
+      |    "seeAlso": [
+      |      "https://example.com/bar"
+      |    ]
+      |  }
+      |]}
+      |""".trimMargin()
+    val spdxLicenses = SpdxLicenses.parseJson(json)
+    assertEquals(
+      SpdxLicense("FOO-1.0", "Foo License", "https://example.com/foo"),
+      spdxLicenses.findByUrl("http://example.com/foo")
+    )
+    assertEquals(
+      SpdxLicense("FOO-1.0", "Foo License", "https://example.com/foo"),
+      spdxLicenses.findByUrl("https://example.com/foo")
+    )
+    assertNull(spdxLicenses.findByUrl("http://example.com/bar"))
+    assertEquals(
+      SpdxLicense("BAR-1.0", "Bar License", "https://example.com/bar"),
+      spdxLicenses.findByUrl("https://example.com/bar")
+    )
+  }
+
+  @Test fun spdxUrlSupported() {
+    val json = """
+      |{"licenses":[
+      |  {
+      |    "licenseId": "FOO-1.0",
+      |    "name": "Foo License",
+      |    "detailsUrl": "./FOO-1.0.html",
+      |    "seeAlso": [
+      |      "http://example.com/foo"
+      |    ]
+      |  }
+      |]}
+      |""".trimMargin()
+    val spdxLicenses = SpdxLicenses.parseJson(json)
+    assertEquals(
+      SpdxLicense("FOO-1.0", "Foo License", "https://example.com/foo"),
+      spdxLicenses.findByUrl("http://example.com/foo")
+    )
+    assertEquals(
+      SpdxLicense("FOO-1.0", "Foo License", "https://example.com/foo"),
+      spdxLicenses.findByUrl("https://spdx.org/licenses/FOO-1.0.html")
+    )
+  }
+}


### PR DESCRIPTION
This allows testing in isolation. And as a result of testing, fix a bug where we were not allowing the 'https' variant of license URLs.

This also changes the behavior around duplicated license URLs (#28) to prefer the shortest identifier for now. At the very least this is probably the one you want, and it makes the behavior deterministic rather than relying on the JSON order.