### PR TITLE
Add fallback id for MIT url licenses.

### DIFF
--- a/src/main/kotlin/app/cash/licensee/licenses.kt
+++ b/src/main/kotlin/app/cash/licensee/licenses.kt
@@ -66,6 +66,10 @@ private fun PomLicense.toSpdxOrNull(): SpdxLicense? {
       "http://creativecommons.org/publicdomain/zero/1.0/",
       -> "CC0-1.0"
 
+      "https://opensource.org/licenses/mit-license",
+      "http://www.opensource.org/licenses/mit-license.php",
+      -> "MIT"
+
       else -> null
     }
     fallbackId?.let(spdxLicenses::findByIdentifier)?.let { license ->


### PR DESCRIPTION
```
org.slf4j:slf4j-api:1.7.30
 - ERROR: Unknown license URL 'http://www.opensource.org/licenses/mit-license.php' is NOT allowed
com.benasher44:uuid-jvm:0.3.0
 - ERROR: Unknown license URL 'https://opensource.org/licenses/mit-license' is NOT allowed
 ```