### PR TITLE
Add http://www.opensource.org/licenses/LGPL-2.1 as LGPL-2.1-only

### DIFF
--- a/src/main/kotlin/app/cash/licensee/licenses.kt
+++ b/src/main/kotlin/app/cash/licensee/licenses.kt
@@ -66,6 +66,9 @@ private fun PomLicense.toSpdxOrNull(): SpdxLicense? {
       "http://creativecommons.org/publicdomain/zero/1.0/",
       -> "CC0-1.0"
 
+      "http://www.opensource.org/licenses/LGPL-2.1",
+      -> "LGPL-2.1-only"
+
       else -> null
     }
     fallbackId?.let(spdxLicenses::findByIdentifier)?.let { license ->


### PR DESCRIPTION
```
org.hibernate:hibernate-core:5.3.12.Final
 - ERROR: Unknown license URL 'http://www.opensource.org/licenses/LGPL-2.1' is NOT allowed
```