### PR TITLE
Licenses from child poms override parents

### DIFF
--- a/src/main/kotlin/app/cash/licensee/dependencyGraph.kt
+++ b/src/main/kotlin/app/cash/licensee/dependencyGraph.kt
@@ -250,7 +250,9 @@ internal fun loadPomInfo(
         id = DependencyCoordinates(group, artifact, version),
         depth = depth + 1
       )
-      licenses += parentPomInfo.licenses
+      if (licenses.isEmpty()) {
+        licenses += parentPomInfo.licenses
+      }
       if (scm == null) {
         scm = parentPomInfo.scm
       }

--- a/src/test/fixtures/pom-with-inheritance-from-both/build.gradle
+++ b/src/test/fixtures/pom-with-inheritance-from-both/build.gradle
@@ -21,7 +21,6 @@ dependencies {
 
 licensee {
   allow('Apache-2.0')
-  allow('MPL-2.0')
 }
 
 repositories {

--- a/src/test/fixtures/pom-with-inheritance-from-both/expected/build/reports/licensee/artifacts.json
+++ b/src/test/fixtures/pom-with-inheritance-from-both/expected/build/reports/licensee/artifacts.json
@@ -9,11 +9,6 @@
                 "identifier": "Apache-2.0",
                 "name": "Apache License 2.0",
                 "url": "https://www.apache.org/licenses/LICENSE-2.0"
-            },
-            {
-                "identifier": "MPL-2.0",
-                "name": "Mozilla Public License 2.0",
-                "url": "https://www.mozilla.org/MPL/2.0/"
             }
         ],
         "scm": {


### PR DESCRIPTION
Per 'licenses' not being included in the merge list here: https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#project-inheritance

Closes #87 