### PR TITLE
Add fallback url for BSD-2-Clause

### DIFF
--- a/src/main/kotlin/app/cash/licensee/licenses.kt
+++ b/src/main/kotlin/app/cash/licensee/licenses.kt
@@ -76,6 +76,7 @@ private fun PomLicense.toSpdxOrNull(): SpdxLicense? {
       -> "MIT"
 
       "http://www.opensource.org/licenses/bsd-license",
+      "http://www.opensource.org/licenses/bsd-license.php",
       -> "BSD-2-Clause"
 
       "http://opensource.org/licenses/BSD-3-Clause",


### PR DESCRIPTION
```
org.hamcrest:hamcrest-core:1.3
 - ERROR: Unknown license URL 'http://www.opensource.org/licenses/bsd-license.php' is NOT allowed
```