### PR TITLE
Add Fallback URL for EPL-2.0

### DIFF
--- a/src/main/kotlin/app/cash/licensee/licenses.kt
+++ b/src/main/kotlin/app/cash/licensee/licenses.kt
@@ -88,6 +88,9 @@ private fun PomLicense.toSpdxOrNull(): SpdxLicense? {
       "http://www.eclipse.org/org/documents/epl-v10.php",
       -> "EPL-1.0"
 
+      "https://www.eclipse.org/legal/epl-2.0/",
+      -> "EPL-2.0"
+
       else -> null
     }
     fallbackId?.let(SpdxLicenses.embedded::findByIdentifier)?.let { license ->


### PR DESCRIPTION
Use case: 
A pom file has a trailing slash in the license url so it is not recognized as EPL-2.0 although it is inside the json file: ` - Unknown license URL 'https://www.eclipse.org/legal/epl-2.0/' is NOT allowed`