### PR TITLE
Make unused allowed SPDX-identifier, license-url and allowed dependency warnings configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+**Added**
+
+- Make unused allowed SPDX-identifier, license-url and allowed dependency warnings configurable
+
 ## [1.6.0] - 2022-10-26
 
 **Added**

--- a/src/main/kotlin/app/cash/licensee/licenseValidation.kt
+++ b/src/main/kotlin/app/cash/licensee/licenseValidation.kt
@@ -21,6 +21,9 @@ internal data class ValidationConfig(
   val allowedIdentifiers: Set<String>,
   val allowedUrls: Set<String>,
   val allowedCoordinates: Map<DependencyCoordinates, String?>,
+  val unusedAllowAction: UnusedLicenseConfigurationAction,
+  val unusedAllowUrlAction: UnusedLicenseConfigurationAction,
+  val unusedAllowDependencyAction: UnusedLicenseConfigurationAction,
 ) : Serializable
 
 internal data class DependencyCoordinates(
@@ -137,13 +140,22 @@ internal fun validateArtifacts(
   }
 
   for (unusedAllowedIdentifier in unusedAllowedIdentifiers) {
-    configResults += ValidationResult.Warning("Allowed SPDX identifier '$unusedAllowedIdentifier' is unused")
+    when (validationConfig.unusedAllowAction) {
+      UnusedLicenseConfigurationAction.LOG -> configResults += ValidationResult.Warning("Allowed SPDX identifier '$unusedAllowedIdentifier' is unused")
+      UnusedLicenseConfigurationAction.IGNORE -> Unit
+    }
   }
   for (unusedAllowedUrl in unusedAllowedUrls) {
-    configResults += ValidationResult.Warning("Allowed license URL '$unusedAllowedUrl' is unused")
+    when (validationConfig.unusedAllowUrlAction) {
+      UnusedLicenseConfigurationAction.LOG -> configResults += ValidationResult.Warning("Allowed license URL '$unusedAllowedUrl' is unused")
+      UnusedLicenseConfigurationAction.IGNORE -> Unit
+    }
   }
   for (unusedAllowedCoordinate in unusedAllowedCoordinates) {
-    configResults += ValidationResult.Warning("Allowed dependency '${unusedAllowedCoordinate.group}:${unusedAllowedCoordinate.artifact}:${unusedAllowedCoordinate.version}' is unused")
+    when (validationConfig.unusedAllowDependencyAction) {
+      UnusedLicenseConfigurationAction.LOG -> configResults += ValidationResult.Warning("Allowed dependency '${unusedAllowedCoordinate.group}:${unusedAllowedCoordinate.artifact}:${unusedAllowedCoordinate.version}' is unused")
+      UnusedLicenseConfigurationAction.IGNORE -> Unit
+    }
   }
 
   return ValidationResults(configResults, artifactResultMap)

--- a/src/main/kotlin/app/cash/licensee/pluginExtension.kt
+++ b/src/main/kotlin/app/cash/licensee/pluginExtension.kt
@@ -196,11 +196,56 @@ interface LicenseeExtension {
     fun because(reason: String)
     var transitive: Boolean
   }
+
+  /**
+   * Configure behavior when an unused allowDependency configuration is detected.
+   *
+   * ```
+   * licensee {
+   *   unusedAllowAction(LOG)
+   * }
+   * ```
+   *
+   * The default behavior is to [log][UnusedLicenseConfigurationAction.LOG].
+   */
+  fun unusedAllowAction(level: UnusedLicenseConfigurationAction)
+
+  /**
+   * Configure behavior when an unused allowUrl configuration is detected.
+   *
+   * ```
+   * licensee {
+   *   unusedAllowUrlAction(LOG)
+   * }
+   * ```
+   *
+   * The default behavior is to [log][UnusedLicenseConfigurationAction.LOG].
+   */
+  fun unusedAllowUrlAction(level: UnusedLicenseConfigurationAction)
+
+  /**
+   * Configure behavior when an unused allowDependency configuration is detected.
+   *
+   * ```
+   * licensee {
+   *   unusedAllowDependenciesAction(LOG)
+   * }
+   * ```
+   *
+   * The default behavior is to [log][UnusedLicenseConfigurationAction.LOG].
+   */
+  fun unusedAllowDependenciesAction(level: UnusedLicenseConfigurationAction)
 }
 
 @Suppress("unused") // Public API.
 enum class ViolationAction {
   FAIL,
+  LOG,
+  IGNORE,
+}
+
+@Suppress("unused") // Public API.
+enum class UnusedLicenseConfigurationAction {
   LOG,
   IGNORE,
 }
@@ -211,6 +256,9 @@ internal class MutableLicenseeExtension : LicenseeExtension {
   private val allowedDependencies = mutableMapOf<DependencyCoordinates, String?>()
   private val ignoredGroupIds = mutableMapOf<String, IgnoredData>()
   private val ignoredCoordinates = mutableMapOf<String, MutableMap<String, IgnoredData>>()
+  private var unusedAllowAction = UnusedLicenseConfigurationAction.LOG
+  private var unusedAllowUrlAction = UnusedLicenseConfigurationAction.LOG
+  private var unusedAllowDependencyAction = UnusedLicenseConfigurationAction.LOG
 
   var violationAction = ViolationAction.FAIL
     private set
@@ -227,6 +275,9 @@ internal class MutableLicenseeExtension : LicenseeExtension {
       allowedIdentifiers.toSet(),
       allowedUrls.toSet(),
       allowedDependencies.toMap(),
+      unusedAllowAction = unusedAllowAction,
+      unusedAllowUrlAction = unusedAllowUrlAction,
+      unusedAllowDependencyAction = unusedAllowDependencyAction,
     )
   }
 
@@ -300,5 +351,17 @@ internal class MutableLicenseeExtension : LicenseeExtension {
 
   override fun violationAction(level: ViolationAction) {
     violationAction = level
+  }
+
+  override fun unusedAllowAction(level: UnusedLicenseConfigurationAction) {
+    unusedAllowAction = level
+  }
+
+  override fun unusedAllowUrlAction(level: UnusedLicenseConfigurationAction) {
+    unusedAllowUrlAction = level
+  }
+
+  override fun unusedAllowDependenciesAction(level: UnusedLicenseConfigurationAction) {
+    unusedAllowDependencyAction = level
   }
 }

--- a/src/test/kotlin/app/cash/licensee/LicenseValidationTest.kt
+++ b/src/test/kotlin/app/cash/licensee/LicenseValidationTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.licensee
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class LicenseValidationTest {
+
+  private val mitLicensedArtifact = ArtifactDetail(
+    "foo.bar",
+    "baz",
+    "1.0.0",
+    spdxLicenses = setOf(
+      SpdxLicense(
+        "MIT",
+        "MIT License",
+        "https://spdx.org/licenses/MIT.html",
+      ),
+    ),
+  )
+
+  @Test fun ignoreUnusedAllow() {
+    val configUnderTest = ValidationConfig(
+      allowedIdentifiers = setOf("MIT-0", "MIT"),
+      allowedUrls = emptySet(),
+      allowedCoordinates = emptyMap(),
+      unusedAllowAction = UnusedLicenseConfigurationAction.IGNORE,
+      unusedAllowUrlAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowDependencyAction = UnusedLicenseConfigurationAction.LOG,
+    )
+
+    assertEquals(
+      validateArtifacts(configUnderTest, listOf(mitLicensedArtifact)).configResults,
+      emptyList<ValidationResult>(),
+    )
+  }
+
+  @Test fun reportUnusedAllow() {
+    val configUnderTest = ValidationConfig(
+      allowedIdentifiers = setOf("MIT-0", "MIT"),
+      allowedUrls = emptySet(),
+      allowedCoordinates = emptyMap(),
+      unusedAllowAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowUrlAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowDependencyAction = UnusedLicenseConfigurationAction.LOG,
+    )
+
+    assertEquals(
+      validateArtifacts(configUnderTest, listOf(mitLicensedArtifact)).configResults,
+      listOf(ValidationResult.Warning("Allowed SPDX identifier 'MIT-0' is unused")),
+    )
+  }
+
+  @Test fun ignoreUnusedAllowUrl() {
+    val configUnderTest = ValidationConfig(
+      allowedIdentifiers = setOf("MIT"),
+      allowedUrls = setOf("https://some-url.com/foo"),
+      allowedCoordinates = emptyMap(),
+      unusedAllowAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowUrlAction = UnusedLicenseConfigurationAction.IGNORE,
+      unusedAllowDependencyAction = UnusedLicenseConfigurationAction.LOG,
+    )
+
+    assertEquals(
+      validateArtifacts(configUnderTest, listOf(mitLicensedArtifact)).configResults,
+      emptyList<ValidationResult>(),
+    )
+  }
+
+  @Test fun reportUnusedAllowUrl() {
+    val configUnderTest = ValidationConfig(
+      allowedIdentifiers = setOf("MIT"),
+      allowedUrls = setOf("https://some-url.com/foo"),
+      allowedCoordinates = emptyMap(),
+      unusedAllowAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowUrlAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowDependencyAction = UnusedLicenseConfigurationAction.LOG,
+    )
+
+    assertEquals(
+      validateArtifacts(configUnderTest, listOf(mitLicensedArtifact)).configResults,
+      listOf(ValidationResult.Warning("Allowed license URL 'https://some-url.com/foo' is unused")),
+    )
+  }
+
+  @Test fun ignoreUnusedAllowDependency() {
+    val configUnderTest = ValidationConfig(
+      allowedIdentifiers = setOf("MIT"),
+      allowedUrls = emptySet(),
+      allowedCoordinates = mapOf(DependencyCoordinates("some.unused", "artifact", "1.0.0") to "Awesome."),
+      unusedAllowAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowUrlAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowDependencyAction = UnusedLicenseConfigurationAction.IGNORE,
+    )
+
+    assertEquals(
+      validateArtifacts(configUnderTest, listOf(mitLicensedArtifact)).configResults,
+      emptyList<ValidationResult>(),
+    )
+  }
+
+  @Test fun reportUnusedAllowDependency() {
+    val configUnderTest = ValidationConfig(
+      allowedIdentifiers = setOf("MIT"),
+      allowedUrls = emptySet(),
+      allowedCoordinates = mapOf(DependencyCoordinates("some.unused", "artifact", "1.0.0") to "Awesome."),
+      unusedAllowAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowUrlAction = UnusedLicenseConfigurationAction.LOG,
+      unusedAllowDependencyAction = UnusedLicenseConfigurationAction.LOG,
+    )
+
+    assertEquals(
+      validateArtifacts(configUnderTest, listOf(mitLicensedArtifact)).configResults,
+      listOf(ValidationResult.Warning("Allowed dependency 'some.unused:artifact:1.0.0' is unused")),
+    )
+  }
+}


### PR DESCRIPTION
Closes #134 