### PR TITLE
Fix using deprecated Gradle methods

### DIFF
--- a/src/test/fixtures/dependency-substitution-replace-local-with-remote/build.gradle
+++ b/src/test/fixtures/dependency-substitution-replace-local-with-remote/build.gradle
@@ -16,7 +16,7 @@ allprojects {
   configurations.all {
     resolutionStrategy {
       dependencySubstitution {
-        substitute project(':other') with module('com.example:example:1.0.0')
+        substitute project(':other') using module('com.example:example:1.0.0')
       }
     }
   }

--- a/src/test/fixtures/dependency-substitution-replace-remote-with-include-build-ignored/settings.gradle
+++ b/src/test/fixtures/dependency-substitution-replace-remote-with-include-build-ignored/settings.gradle
@@ -2,6 +2,6 @@ include ':'
 
 includeBuild('other') {
   dependencySubstitution {
-    substitute module('com.example:example') with project(':')
+    substitute module('com.example:example') using project(':')
   }
 }

--- a/src/test/fixtures/dependency-substitution-replace-remote-with-local-ignored/build.gradle
+++ b/src/test/fixtures/dependency-substitution-replace-remote-with-local-ignored/build.gradle
@@ -16,7 +16,7 @@ allprojects {
   configurations.all {
     resolutionStrategy {
       dependencySubstitution {
-        substitute module('com.example:example:1.0.0') with project(':other')
+        substitute module('com.example:example:1.0.0') using project(':other')
       }
     }
   }

--- a/src/test/fixtures/plugin-kotlin-js/build.gradle
+++ b/src/test/fixtures/plugin-kotlin-js/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'org.jetbrains.kotlin.js'
 apply plugin: 'app.cash.licensee'
 
 kotlin {
-  js {
+  js(IR) {
     nodejs()
   }
 }

--- a/src/test/fixtures/plugin-kotlin-mpp-report-dir/build.gradle
+++ b/src/test/fixtures/plugin-kotlin-mpp-report-dir/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.licensee'
 
 kotlin {
-  js {
+  js(IR) {
     nodejs()
   }
   jvm()

--- a/src/test/fixtures/plugin-kotlin-mpp/build.gradle
+++ b/src/test/fixtures/plugin-kotlin-mpp/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.licensee'
 
 kotlin {
-  js {
+  js(IR) {
     nodejs()
   }
   jvm()


### PR DESCRIPTION
Unfortunately, these changes still don't work with Gradle 8, the configuration cache multiplatform tests fail due to https://youtrack.jetbrains.com/issue/KT-55051/MetadataDependencyTransformationTask-is-not-compatible-with-Gradle-configuration-cache