### PR TITLE
AGP: Use api artifact only

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.8.10"
 
 [libraries]
-androidGradlePlugin = "com.android.tools.build:gradle:7.4.2"
+androidGradlePlugin = "com.android.tools.build:gradle-api:7.4.2"
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinSerializationPlugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 spotlessPlugin = "com.diffplug.spotless:spotless-plugin-gradle:6.18.0"


### PR DESCRIPTION
This artifact does only contain the api, not the implementation, and should be used by plugin authors in the future. It already works today.

https://developer.android.com/build/releases/gradle-plugin-roadmap