### PR TITLE
Fix running tests on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /.gradle
 build
 /reports
+
+# Android
+/local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 test {
   dependsOn(':publishAllPublicationsToTestingRepository')
   systemProperty('licenseeVersion', VERSION_NAME)
+  systemProperty('line.separator', '\n')
 
   testLogging {
     if (System.getenv("CI") == "true") {

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ publishing {
   repositories {
     maven {
       name = "testing"
-      url = "${rootProject.buildDir}/localMaven"
+      url = "${rootProject.projectDir}/build/localMaven"
     }
   }
 }

--- a/src/test/fixtures/.gitattributes
+++ b/src/test/fixtures/.gitattributes
@@ -1,0 +1,2 @@
+**/expected/**/artifacts.json text eol=lf
+**/expected/**/validation.txt text eol=lf


### PR DESCRIPTION
Replacement for parts of https://github.com/cashapp/licensee/pull/94. All tests now finish successfully on Windows.