### PR TITLE
Bump AGP to 8.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,23 @@ tasks.named("test") {
     }
     exceptionFormat "full"
   }
+  // AGP 8+ requires JVM 17+.
+  javaLauncher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(20)
+  }
+
+  // Required to test configuration cache in tests when using withDebug()
+  // https://github.com/gradle/gradle/issues/22765#issuecomment-1339427241
+  jvmArgs(
+    "--add-opens",
+    "java.base/java.util=ALL-UNNAMED",
+    "--add-opens",
+    "java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+    "--add-opens",
+    "java.base/java.lang.invoke=ALL-UNNAMED",
+    "--add-opens",
+    "java.base/java.net=ALL-UNNAMED",
+  )
 }
 
 def fixtures = file('src/test/fixtures')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.9.0"
-agp = "7.4.2"
+agp = "8.1.0"
 
 [libraries]
 androidGradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,10 @@ pluginManagement {
   }
 }
 
+plugins {
+  id "org.gradle.toolchains.foojay-resolver-convention" version "0.6.0"
+}
+
 dependencyResolutionManagement {
   repositories {
     mavenCentral()


### PR DESCRIPTION
JVM 20 isn't supported with the precompiled included build used by the tests, because Gradle 8.2.1 uses Kotlin 1.8.22. I could switch from Kotlin to Groovy, or we just use JVM 17 until Gradle 8.3 is out.