### PR TITLE
Bump Kotlin to 1.9.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.0"
+kotlin = "1.9.10"
 agp = "8.1.1"
 
 [libraries]

--- a/src/test/fixtures/plugin-kotlin-js/expected/build/reports/licensee/artifacts.json
+++ b/src/test/fixtures/plugin-kotlin-js/expected/build/reports/licensee/artifacts.json
@@ -14,7 +14,7 @@
     {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-dom-api-compat",
-        "version": "1.9.0",
+        "version": "1.9.10",
         "name": "Kotlin Dom Api Compat",
         "spdxLicenses": [
             {
@@ -30,7 +30,7 @@
     {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-common",
-        "version": "1.9.0",
+        "version": "1.9.10",
         "name": "Kotlin Stdlib Common",
         "spdxLicenses": [
             {
@@ -46,7 +46,7 @@
     {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-js",
-        "version": "1.9.0",
+        "version": "1.9.10",
         "name": "Kotlin Stdlib Js",
         "spdxLicenses": [
             {

--- a/src/test/fixtures/plugin-kotlin-js/expected/build/reports/licensee/validation.txt
+++ b/src/test/fixtures/plugin-kotlin-js/expected/build/reports/licensee/validation.txt
@@ -1,8 +1,8 @@
 com.example:example:1.0.0
  - SPDX identifier 'Apache-2.0' allowed
-org.jetbrains.kotlin:kotlin-dom-api-compat:1.9.0
+org.jetbrains.kotlin:kotlin-dom-api-compat:1.9.10
  - SPDX identifier 'Apache-2.0' allowed
-org.jetbrains.kotlin:kotlin-stdlib-common:1.9.0
+org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10
  - SPDX identifier 'Apache-2.0' allowed
-org.jetbrains.kotlin:kotlin-stdlib-js:1.9.0
+org.jetbrains.kotlin:kotlin-stdlib-js:1.9.10
  - SPDX identifier 'Apache-2.0' allowed

--- a/src/test/fixtures/plugin-kotlin-mpp-report-dir/expected/build/my-reports/licensee/js/artifacts.json
+++ b/src/test/fixtures/plugin-kotlin-mpp-report-dir/expected/build/my-reports/licensee/js/artifacts.json
@@ -26,7 +26,7 @@
     {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-dom-api-compat",
-        "version": "1.9.0",
+        "version": "1.9.10",
         "name": "Kotlin Dom Api Compat",
         "spdxLicenses": [
             {
@@ -42,7 +42,7 @@
     {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-js",
-        "version": "1.9.0",
+        "version": "1.9.10",
         "name": "Kotlin Stdlib Js",
         "spdxLicenses": [
             {

--- a/src/test/fixtures/plugin-kotlin-mpp-report-dir/expected/build/my-reports/licensee/js/validation.txt
+++ b/src/test/fixtures/plugin-kotlin-mpp-report-dir/expected/build/my-reports/licensee/js/validation.txt
@@ -2,7 +2,7 @@ com.example:example-a:1.0.0
  - SPDX identifier 'Apache-2.0' allowed
 com.example:example-b:1.0.0
  - SPDX identifier 'Apache-2.0' allowed
-org.jetbrains.kotlin:kotlin-dom-api-compat:1.9.0
+org.jetbrains.kotlin:kotlin-dom-api-compat:1.9.10
  - SPDX identifier 'Apache-2.0' allowed
-org.jetbrains.kotlin:kotlin-stdlib-js:1.9.0
+org.jetbrains.kotlin:kotlin-stdlib-js:1.9.10
  - SPDX identifier 'Apache-2.0' allowed

--- a/src/test/fixtures/plugin-kotlin-mpp/expected/build/reports/licensee/js/artifacts.json
+++ b/src/test/fixtures/plugin-kotlin-mpp/expected/build/reports/licensee/js/artifacts.json
@@ -26,7 +26,7 @@
     {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-dom-api-compat",
-        "version": "1.9.0",
+        "version": "1.9.10",
         "name": "Kotlin Dom Api Compat",
         "spdxLicenses": [
             {
@@ -42,7 +42,7 @@
     {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-js",
-        "version": "1.9.0",
+        "version": "1.9.10",
         "name": "Kotlin Stdlib Js",
         "spdxLicenses": [
             {

--- a/src/test/fixtures/plugin-kotlin-mpp/expected/build/reports/licensee/js/validation.txt
+++ b/src/test/fixtures/plugin-kotlin-mpp/expected/build/reports/licensee/js/validation.txt
@@ -2,7 +2,7 @@ com.example:example-a:1.0.0
  - SPDX identifier 'Apache-2.0' allowed
 com.example:example-b:1.0.0
  - SPDX identifier 'Apache-2.0' allowed
-org.jetbrains.kotlin:kotlin-dom-api-compat:1.9.0
+org.jetbrains.kotlin:kotlin-dom-api-compat:1.9.10
  - SPDX identifier 'Apache-2.0' allowed
-org.jetbrains.kotlin:kotlin-stdlib-js:1.9.0
+org.jetbrains.kotlin:kotlin-stdlib-js:1.9.10
  - SPDX identifier 'Apache-2.0' allowed


### PR DESCRIPTION
Another hint the current implementation does not include the stdlib for Kotlin/JVM projects. In theory, updating the Kotlin version should result in updating the fixture files in many places due to using the stdlib.