### PR TITLE
Add fallback URL for ISC

### DIFF
--- a/src/main/kotlin/app/cash/licensee/licensesFallback.kt
+++ b/src/main/kotlin/app/cash/licensee/licensesFallback.kt
@@ -88,6 +88,9 @@ internal val fallbackUrls = buildMap {
     add("http://api.github.com/licenses/epl-2.0")
     add("https://api.github.com/licenses/epl-2.0")
   }
+  putLicense("ISC") {
+    add("https://opensource.org/licenses/isc-license.txt")
+  }
 }
 
 private fun MutableMap<String, List<SpdxLicense>>.putLicense(


### PR DESCRIPTION
Came across this when adding [kotlin-result](https://github.com/michaelbull/kotlin-result/blob/96ce1c18d9795c498ea058ad0b9f21c001d00edb/build.gradle.kts#L125) in a project that uses Licensee.
