### PR TITLE
Do not log empty line when unused warnings are not logged

### DIFF
--- a/src/main/kotlin/app/cash/licensee/task.kt
+++ b/src/main/kotlin/app/cash/licensee/task.kt
@@ -308,8 +308,9 @@ abstract class LicenseeTask : DefaultTask() {
     if (validationResult.configResults.isNotEmpty() && validationResult.artifactResults.isNotEmpty()) {
       validationReport.appendLine()
       // We know these are always at warning or error level, so use lifecycle for space.
-      if (unusedWarningLevel > INFO || unusedErrorLevel > INFO || logger.isInfoEnabled)
+      if (unusedWarningLevel > INFO || unusedErrorLevel > INFO || logger.isInfoEnabled) {
         logger.log(lifecycleLevel, "")
+      }
     }
     for ((artifactDetail, results) in validationResult.artifactResults) {
       val coordinateHeader = buildString {

--- a/src/main/kotlin/app/cash/licensee/task.kt
+++ b/src/main/kotlin/app/cash/licensee/task.kt
@@ -308,7 +308,8 @@ abstract class LicenseeTask : DefaultTask() {
     if (validationResult.configResults.isNotEmpty() && validationResult.artifactResults.isNotEmpty()) {
       validationReport.appendLine()
       // We know these are always at warning or error level, so use lifecycle for space.
-      logger.log(lifecycleLevel, "")
+      if (unusedWarningLevel > INFO || unusedErrorLevel > INFO || logger.isInfoEnabled)
+        logger.log(lifecycleLevel, "")
     }
     for ((artifactDetail, results) in validationResult.artifactResults) {
       val coordinateHeader = buildString {

--- a/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
+++ b/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
@@ -263,6 +263,7 @@ class LicenseePluginFixtureTest {
       |WARNING: Allowed .*? is unused
       """.trimMargin(),
     )
+    assertThat(result.output).doesNotContainMatch("""\n\n> Task :licensee""")
   }
 
   @Test fun unusedWarn(

--- a/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
+++ b/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
@@ -263,7 +263,7 @@ class LicenseePluginFixtureTest {
       |WARNING: Allowed .*? is unused
       """.trimMargin(),
     )
-    assertThat(result.output).doesNotContainMatch("""\n\n> Task :licensee""")
+    assertThat(result.output).doesNotContain("\n\n> Task :licensee")
   }
 
   @Test fun unusedWarn(


### PR DESCRIPTION
With the changes in https://github.com/cashapp/licensee/pull/285 there's now scenarios where only the empty-line is logged at lifecycle level. When using a rich console this results in the task appearing in the output even though it doesn't really log anything.

I am not completely happy with the way that I adjusted the test because it could be that there's another reason for an extra empty line but also wan't sure how this could be tested better. At least the test failed before making the change and after the change is passes