### PR TITLE
Update licenses

### DIFF
--- a/src/main/resources/app/cash/licensee/licenses.json
+++ b/src/main/resources/app/cash/licensee/licenses.json
@@ -1,11 +1,11 @@
 {
-    "licenseListVersion": "3.22",
+    "licenseListVersion": "3.23",
     "licenses": [
         {
             "reference": "https://spdx.org/licenses/0BSD.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/0BSD.json",
-            "referenceNumber": 244,
+            "referenceNumber": 78,
             "name": "BSD Zero Clause License",
             "licenseId": "0BSD",
             "seeAlso": [
@@ -18,7 +18,7 @@
             "reference": "https://spdx.org/licenses/AAL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AAL.json",
-            "referenceNumber": 169,
+            "referenceNumber": 433,
             "name": "Attribution Assurance License",
             "licenseId": "AAL",
             "seeAlso": [
@@ -30,7 +30,7 @@
             "reference": "https://spdx.org/licenses/ADSL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ADSL.json",
-            "referenceNumber": 591,
+            "referenceNumber": 498,
             "name": "Amazon Digital Services License",
             "licenseId": "ADSL",
             "seeAlso": [
@@ -42,7 +42,7 @@
             "reference": "https://spdx.org/licenses/AFL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
-            "referenceNumber": 345,
+            "referenceNumber": 106,
             "name": "Academic Free License v1.1",
             "licenseId": "AFL-1.1",
             "seeAlso": [
@@ -56,7 +56,7 @@
             "reference": "https://spdx.org/licenses/AFL-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
-            "referenceNumber": 123,
+            "referenceNumber": 628,
             "name": "Academic Free License v1.2",
             "licenseId": "AFL-1.2",
             "seeAlso": [
@@ -70,7 +70,7 @@
             "reference": "https://spdx.org/licenses/AFL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
-            "referenceNumber": 167,
+            "referenceNumber": 366,
             "name": "Academic Free License v2.0",
             "licenseId": "AFL-2.0",
             "seeAlso": [
@@ -83,7 +83,7 @@
             "reference": "https://spdx.org/licenses/AFL-2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
-            "referenceNumber": 122,
+            "referenceNumber": 220,
             "name": "Academic Free License v2.1",
             "licenseId": "AFL-2.1",
             "seeAlso": [
@@ -96,7 +96,7 @@
             "reference": "https://spdx.org/licenses/AFL-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
-            "referenceNumber": 27,
+            "referenceNumber": 599,
             "name": "Academic Free License v3.0",
             "licenseId": "AFL-3.0",
             "seeAlso": [
@@ -110,7 +110,7 @@
             "reference": "https://spdx.org/licenses/AGPL-1.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
-            "referenceNumber": 403,
+            "referenceNumber": 374,
             "name": "Affero General Public License v1.0",
             "licenseId": "AGPL-1.0",
             "seeAlso": [
@@ -123,7 +123,7 @@
             "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
-            "referenceNumber": 275,
+            "referenceNumber": 310,
             "name": "Affero General Public License v1.0 only",
             "licenseId": "AGPL-1.0-only",
             "seeAlso": [
@@ -135,7 +135,7 @@
             "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
-            "referenceNumber": 163,
+            "referenceNumber": 418,
             "name": "Affero General Public License v1.0 or later",
             "licenseId": "AGPL-1.0-or-later",
             "seeAlso": [
@@ -147,7 +147,7 @@
             "reference": "https://spdx.org/licenses/AGPL-3.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
-            "referenceNumber": 446,
+            "referenceNumber": 631,
             "name": "GNU Affero General Public License v3.0",
             "licenseId": "AGPL-3.0",
             "seeAlso": [
@@ -161,7 +161,7 @@
             "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
-            "referenceNumber": 76,
+            "referenceNumber": 495,
             "name": "GNU Affero General Public License v3.0 only",
             "licenseId": "AGPL-3.0-only",
             "seeAlso": [
@@ -175,7 +175,7 @@
             "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
-            "referenceNumber": 554,
+            "referenceNumber": 228,
             "name": "GNU Affero General Public License v3.0 or later",
             "licenseId": "AGPL-3.0-or-later",
             "seeAlso": [
@@ -189,7 +189,7 @@
             "reference": "https://spdx.org/licenses/AMDPLPA.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
-            "referenceNumber": 396,
+            "referenceNumber": 100,
             "name": "AMD's plpa_map.c License",
             "licenseId": "AMDPLPA",
             "seeAlso": [
@@ -201,7 +201,7 @@
             "reference": "https://spdx.org/licenses/AML.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AML.json",
-            "referenceNumber": 352,
+            "referenceNumber": 2,
             "name": "Apple MIT License",
             "licenseId": "AML",
             "seeAlso": [
@@ -210,10 +210,23 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/AML-glslang.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/AML-glslang.json",
+            "referenceNumber": 370,
+            "name": "AML glslang variant License",
+            "licenseId": "AML-glslang",
+            "seeAlso": [
+                "https://github.com/KhronosGroup/glslang/blob/main/LICENSE.txt#L949",
+                "https://docs.omniverse.nvidia.com/install-guide/latest/common/licenses.html"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/AMPAS.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
-            "referenceNumber": 463,
+            "referenceNumber": 267,
             "name": "Academy of Motion Picture Arts and Sciences BSD",
             "licenseId": "AMPAS",
             "seeAlso": [
@@ -225,7 +238,7 @@
             "reference": "https://spdx.org/licenses/ANTLR-PD.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
-            "referenceNumber": 530,
+            "referenceNumber": 586,
             "name": "ANTLR Software Rights Notice",
             "licenseId": "ANTLR-PD",
             "seeAlso": [
@@ -237,7 +250,7 @@
             "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
-            "referenceNumber": 194,
+            "referenceNumber": 133,
             "name": "ANTLR Software Rights Notice with license fallback",
             "licenseId": "ANTLR-PD-fallback",
             "seeAlso": [
@@ -249,7 +262,7 @@
             "reference": "https://spdx.org/licenses/APAFML.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/APAFML.json",
-            "referenceNumber": 386,
+            "referenceNumber": 376,
             "name": "Adobe Postscript AFM License",
             "licenseId": "APAFML",
             "seeAlso": [
@@ -261,7 +274,7 @@
             "reference": "https://spdx.org/licenses/APL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
-            "referenceNumber": 131,
+            "referenceNumber": 226,
             "name": "Adaptive Public License 1.0",
             "licenseId": "APL-1.0",
             "seeAlso": [
@@ -273,7 +286,7 @@
             "reference": "https://spdx.org/licenses/APSL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
-            "referenceNumber": 268,
+            "referenceNumber": 536,
             "name": "Apple Public Source License 1.0",
             "licenseId": "APSL-1.0",
             "seeAlso": [
@@ -286,7 +299,7 @@
             "reference": "https://spdx.org/licenses/APSL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
-            "referenceNumber": 518,
+            "referenceNumber": 475,
             "name": "Apple Public Source License 1.1",
             "licenseId": "APSL-1.1",
             "seeAlso": [
@@ -298,7 +311,7 @@
             "reference": "https://spdx.org/licenses/APSL-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
-            "referenceNumber": 365,
+            "referenceNumber": 547,
             "name": "Apple Public Source License 1.2",
             "licenseId": "APSL-1.2",
             "seeAlso": [
@@ -310,7 +323,7 @@
             "reference": "https://spdx.org/licenses/APSL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
-            "referenceNumber": 526,
+            "referenceNumber": 147,
             "name": "Apple Public Source License 2.0",
             "licenseId": "APSL-2.0",
             "seeAlso": [
@@ -323,7 +336,7 @@
             "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.json",
-            "referenceNumber": 262,
+            "referenceNumber": 64,
             "name": "ASWF Digital Assets License version 1.0",
             "licenseId": "ASWF-Digital-Assets-1.0",
             "seeAlso": [
@@ -335,7 +348,7 @@
             "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.json",
-            "referenceNumber": 427,
+            "referenceNumber": 8,
             "name": "ASWF Digital Assets License 1.1",
             "licenseId": "ASWF-Digital-Assets-1.1",
             "seeAlso": [
@@ -347,7 +360,7 @@
             "reference": "https://spdx.org/licenses/Abstyles.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
-            "referenceNumber": 221,
+            "referenceNumber": 395,
             "name": "Abstyles License",
             "licenseId": "Abstyles",
             "seeAlso": [
@@ -359,7 +372,7 @@
             "reference": "https://spdx.org/licenses/AdaCore-doc.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/AdaCore-doc.json",
-            "referenceNumber": 249,
+            "referenceNumber": 108,
             "name": "AdaCore Doc License",
             "licenseId": "AdaCore-doc",
             "seeAlso": [
@@ -373,7 +386,7 @@
             "reference": "https://spdx.org/licenses/Adobe-2006.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
-            "referenceNumber": 203,
+            "referenceNumber": 358,
             "name": "Adobe Systems Incorporated Source Code License Agreement",
             "licenseId": "Adobe-2006",
             "seeAlso": [
@@ -382,10 +395,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/Adobe-Display-PostScript.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Adobe-Display-PostScript.json",
+            "referenceNumber": 272,
+            "name": "Adobe Display PostScript License",
+            "licenseId": "Adobe-Display-PostScript",
+            "seeAlso": [
+                "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type=heads#L752"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
-            "referenceNumber": 546,
+            "referenceNumber": 297,
             "name": "Adobe Glyph List License",
             "licenseId": "Adobe-Glyph",
             "seeAlso": [
@@ -397,7 +422,7 @@
             "reference": "https://spdx.org/licenses/Adobe-Utopia.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Adobe-Utopia.json",
-            "referenceNumber": 309,
+            "referenceNumber": 311,
             "name": "Adobe Utopia Font License",
             "licenseId": "Adobe-Utopia",
             "seeAlso": [
@@ -409,7 +434,7 @@
             "reference": "https://spdx.org/licenses/Afmparse.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
-            "referenceNumber": 66,
+            "referenceNumber": 172,
             "name": "Afmparse License",
             "licenseId": "Afmparse",
             "seeAlso": [
@@ -421,7 +446,7 @@
             "reference": "https://spdx.org/licenses/Aladdin.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
-            "referenceNumber": 18,
+            "referenceNumber": 35,
             "name": "Aladdin Free Public License",
             "licenseId": "Aladdin",
             "seeAlso": [
@@ -434,7 +459,7 @@
             "reference": "https://spdx.org/licenses/Apache-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
-            "referenceNumber": 528,
+            "referenceNumber": 463,
             "name": "Apache License 1.0",
             "licenseId": "Apache-1.0",
             "seeAlso": [
@@ -447,7 +472,7 @@
             "reference": "https://spdx.org/licenses/Apache-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
-            "referenceNumber": 287,
+            "referenceNumber": 627,
             "name": "Apache License 1.1",
             "licenseId": "Apache-1.1",
             "seeAlso": [
@@ -461,7 +486,7 @@
             "reference": "https://spdx.org/licenses/Apache-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
-            "referenceNumber": 138,
+            "referenceNumber": 501,
             "name": "Apache License 2.0",
             "licenseId": "Apache-2.0",
             "seeAlso": [
@@ -475,7 +500,7 @@
             "reference": "https://spdx.org/licenses/App-s2p.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
-            "referenceNumber": 444,
+            "referenceNumber": 123,
             "name": "App::s2p License",
             "licenseId": "App-s2p",
             "seeAlso": [
@@ -487,7 +512,7 @@
             "reference": "https://spdx.org/licenses/Arphic-1999.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
-            "referenceNumber": 533,
+            "referenceNumber": 326,
             "name": "Arphic Public License",
             "licenseId": "Arphic-1999",
             "seeAlso": [
@@ -499,7 +524,7 @@
             "reference": "https://spdx.org/licenses/Artistic-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
-            "referenceNumber": 404,
+            "referenceNumber": 278,
             "name": "Artistic License 1.0",
             "licenseId": "Artistic-1.0",
             "seeAlso": [
@@ -512,7 +537,7 @@
             "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
-            "referenceNumber": 595,
+            "referenceNumber": 634,
             "name": "Artistic License 1.0 (Perl)",
             "licenseId": "Artistic-1.0-Perl",
             "seeAlso": [
@@ -524,7 +549,7 @@
             "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
-            "referenceNumber": 62,
+            "referenceNumber": 234,
             "name": "Artistic License 1.0 w/clause 8",
             "licenseId": "Artistic-1.0-cl8",
             "seeAlso": [
@@ -536,7 +561,7 @@
             "reference": "https://spdx.org/licenses/Artistic-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
-            "referenceNumber": 237,
+            "referenceNumber": 222,
             "name": "Artistic License 2.0",
             "licenseId": "Artistic-2.0",
             "seeAlso": [
@@ -551,7 +576,7 @@
             "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
-            "referenceNumber": 125,
+            "referenceNumber": 308,
             "name": "BSD 1-Clause License",
             "licenseId": "BSD-1-Clause",
             "seeAlso": [
@@ -563,7 +588,7 @@
             "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
-            "referenceNumber": 217,
+            "referenceNumber": 232,
             "name": "BSD 2-Clause \"Simplified\" License",
             "licenseId": "BSD-2-Clause",
             "seeAlso": [
@@ -573,10 +598,22 @@
             "isFsfLibre": true
         },
         {
+            "reference": "https://spdx.org/licenses/BSD-2-Clause-Darwin.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Darwin.json",
+            "referenceNumber": 555,
+            "name": "BSD 2-Clause - Ian Darwin variant",
+            "licenseId": "BSD-2-Clause-Darwin",
+            "seeAlso": [
+                "https://github.com/file/file/blob/master/COPYING"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-            "referenceNumber": 570,
+            "referenceNumber": 56,
             "name": "BSD 2-Clause FreeBSD License",
             "licenseId": "BSD-2-Clause-FreeBSD",
             "seeAlso": [
@@ -589,7 +626,7 @@
             "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-            "referenceNumber": 143,
+            "referenceNumber": 530,
             "name": "BSD 2-Clause NetBSD License",
             "licenseId": "BSD-2-Clause-NetBSD",
             "seeAlso": [
@@ -602,7 +639,7 @@
             "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
-            "referenceNumber": 99,
+            "referenceNumber": 200,
             "name": "BSD-2-Clause Plus Patent License",
             "licenseId": "BSD-2-Clause-Patent",
             "seeAlso": [
@@ -614,7 +651,7 @@
             "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
-            "referenceNumber": 577,
+            "referenceNumber": 539,
             "name": "BSD 2-Clause with views sentence",
             "licenseId": "BSD-2-Clause-Views",
             "seeAlso": [
@@ -628,7 +665,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
-            "referenceNumber": 179,
+            "referenceNumber": 409,
             "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "licenseId": "BSD-3-Clause",
             "seeAlso": [
@@ -642,7 +679,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-            "referenceNumber": 213,
+            "referenceNumber": 127,
             "name": "BSD with attribution",
             "licenseId": "BSD-3-Clause-Attribution",
             "seeAlso": [
@@ -654,7 +691,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
-            "referenceNumber": 588,
+            "referenceNumber": 251,
             "name": "BSD 3-Clause Clear License",
             "licenseId": "BSD-3-Clause-Clear",
             "seeAlso": [
@@ -667,7 +704,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-HP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-HP.json",
-            "referenceNumber": 472,
+            "referenceNumber": 189,
             "name": "Hewlett-Packard BSD variant license",
             "licenseId": "BSD-3-Clause-HP",
             "seeAlso": [
@@ -679,7 +716,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-            "referenceNumber": 13,
+            "referenceNumber": 377,
             "name": "Lawrence Berkeley National Labs BSD variant license",
             "licenseId": "BSD-3-Clause-LBNL",
             "seeAlso": [
@@ -691,7 +728,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
-            "referenceNumber": 108,
+            "referenceNumber": 89,
             "name": "BSD 3-Clause Modification",
             "licenseId": "BSD-3-Clause-Modification",
             "seeAlso": [
@@ -703,7 +740,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
-            "referenceNumber": 272,
+            "referenceNumber": 216,
             "name": "BSD 3-Clause No Military License",
             "licenseId": "BSD-3-Clause-No-Military-License",
             "seeAlso": [
@@ -716,7 +753,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-            "referenceNumber": 110,
+            "referenceNumber": 192,
             "name": "BSD 3-Clause No Nuclear License",
             "licenseId": "BSD-3-Clause-No-Nuclear-License",
             "seeAlso": [
@@ -728,7 +765,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-            "referenceNumber": 64,
+            "referenceNumber": 249,
             "name": "BSD 3-Clause No Nuclear License 2014",
             "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
             "seeAlso": [
@@ -740,7 +777,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-            "referenceNumber": 42,
+            "referenceNumber": 437,
             "name": "BSD 3-Clause No Nuclear Warranty",
             "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
             "seeAlso": [
@@ -752,7 +789,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-            "referenceNumber": 341,
+            "referenceNumber": 424,
             "name": "BSD 3-Clause Open MPI variant",
             "licenseId": "BSD-3-Clause-Open-MPI",
             "seeAlso": [
@@ -765,7 +802,7 @@
             "reference": "https://spdx.org/licenses/BSD-3-Clause-Sun.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Sun.json",
-            "referenceNumber": 141,
+            "referenceNumber": 596,
             "name": "BSD 3-Clause Sun Microsystems",
             "licenseId": "BSD-3-Clause-Sun",
             "seeAlso": [
@@ -774,10 +811,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/BSD-3-Clause-acpica.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-acpica.json",
+            "referenceNumber": 306,
+            "name": "BSD 3-Clause acpica variant",
+            "licenseId": "BSD-3-Clause-acpica",
+            "seeAlso": [
+                "https://github.com/acpica/acpica/blob/master/source/common/acfileio.c#L119"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/BSD-3-Clause-flex.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-flex.json",
-            "referenceNumber": 347,
+            "referenceNumber": 388,
             "name": "BSD 3-Clause Flex variant",
             "licenseId": "BSD-3-Clause-flex",
             "seeAlso": [
@@ -789,7 +838,7 @@
             "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
-            "referenceNumber": 575,
+            "referenceNumber": 453,
             "name": "BSD 4-Clause \"Original\" or \"Old\" License",
             "licenseId": "BSD-4-Clause",
             "seeAlso": [
@@ -802,7 +851,7 @@
             "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
-            "referenceNumber": 180,
+            "referenceNumber": 46,
             "name": "BSD 4 Clause Shortened",
             "licenseId": "BSD-4-Clause-Shortened",
             "seeAlso": [
@@ -814,7 +863,7 @@
             "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
-            "referenceNumber": 306,
+            "referenceNumber": 350,
             "name": "BSD-4-Clause (University of California-Specific)",
             "licenseId": "BSD-4-Clause-UC",
             "seeAlso": [
@@ -826,7 +875,7 @@
             "reference": "https://spdx.org/licenses/BSD-4.3RENO.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-4.3RENO.json",
-            "referenceNumber": 539,
+            "referenceNumber": 558,
             "name": "BSD 4.3 RENO License",
             "licenseId": "BSD-4.3RENO",
             "seeAlso": [
@@ -839,7 +888,7 @@
             "reference": "https://spdx.org/licenses/BSD-4.3TAHOE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-4.3TAHOE.json",
-            "referenceNumber": 254,
+            "referenceNumber": 372,
             "name": "BSD 4.3 TAHOE License",
             "licenseId": "BSD-4.3TAHOE",
             "seeAlso": [
@@ -852,7 +901,7 @@
             "reference": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.json",
-            "referenceNumber": 367,
+            "referenceNumber": 466,
             "name": "BSD Advertising Acknowledgement License",
             "licenseId": "BSD-Advertising-Acknowledgement",
             "seeAlso": [
@@ -864,7 +913,7 @@
             "reference": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.json",
-            "referenceNumber": 358,
+            "referenceNumber": 434,
             "name": "BSD with Attribution and HPND disclaimer",
             "licenseId": "BSD-Attribution-HPND-disclaimer",
             "seeAlso": [
@@ -876,7 +925,7 @@
             "reference": "https://spdx.org/licenses/BSD-Inferno-Nettverk.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-Inferno-Nettverk.json",
-            "referenceNumber": 336,
+            "referenceNumber": 423,
             "name": "BSD-Inferno-Nettverk",
             "licenseId": "BSD-Inferno-Nettverk",
             "seeAlso": [
@@ -888,7 +937,7 @@
             "reference": "https://spdx.org/licenses/BSD-Protection.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
-            "referenceNumber": 449,
+            "referenceNumber": 569,
             "name": "BSD Protection License",
             "licenseId": "BSD-Protection",
             "seeAlso": [
@@ -900,7 +949,7 @@
             "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
-            "referenceNumber": 261,
+            "referenceNumber": 36,
             "name": "BSD Source Code Attribution",
             "licenseId": "BSD-Source-Code",
             "seeAlso": [
@@ -909,10 +958,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/BSD-Source-beginning-file.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/BSD-Source-beginning-file.json",
+            "referenceNumber": 486,
+            "name": "BSD Source Code Attribution - beginning of file variant",
+            "licenseId": "BSD-Source-beginning-file",
+            "seeAlso": [
+                "https://github.com/lattera/freebsd/blob/master/sys/cam/cam.c#L4"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/BSD-Systemics.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSD-Systemics.json",
-            "referenceNumber": 451,
+            "referenceNumber": 260,
             "name": "Systemics BSD variant license",
             "licenseId": "BSD-Systemics",
             "seeAlso": [
@@ -921,10 +982,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/BSD-Systemics-W3Works.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/BSD-Systemics-W3Works.json",
+            "referenceNumber": 398,
+            "name": "Systemics W3Works BSD variant license",
+            "licenseId": "BSD-Systemics-W3Works",
+            "seeAlso": [
+                "https://metacpan.org/release/DPARIS/Crypt-Blowfish-2.14/source/COPYRIGHT#L7"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/BSL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
-            "referenceNumber": 529,
+            "referenceNumber": 600,
             "name": "Boost Software License 1.0",
             "licenseId": "BSL-1.0",
             "seeAlso": [
@@ -938,7 +1011,7 @@
             "reference": "https://spdx.org/licenses/BUSL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
-            "referenceNumber": 590,
+            "referenceNumber": 380,
             "name": "Business Source License 1.1",
             "licenseId": "BUSL-1.1",
             "seeAlso": [
@@ -950,7 +1023,7 @@
             "reference": "https://spdx.org/licenses/Baekmuk.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
-            "referenceNumber": 408,
+            "referenceNumber": 512,
             "name": "Baekmuk License",
             "licenseId": "Baekmuk",
             "seeAlso": [
@@ -962,7 +1035,7 @@
             "reference": "https://spdx.org/licenses/Bahyph.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
-            "referenceNumber": 559,
+            "referenceNumber": 57,
             "name": "Bahyph License",
             "licenseId": "Bahyph",
             "seeAlso": [
@@ -974,7 +1047,7 @@
             "reference": "https://spdx.org/licenses/Barr.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Barr.json",
-            "referenceNumber": 555,
+            "referenceNumber": 425,
             "name": "Barr License",
             "licenseId": "Barr",
             "seeAlso": [
@@ -986,7 +1059,7 @@
             "reference": "https://spdx.org/licenses/Beerware.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Beerware.json",
-            "referenceNumber": 137,
+            "referenceNumber": 50,
             "name": "Beerware License",
             "licenseId": "Beerware",
             "seeAlso": [
@@ -999,7 +1072,7 @@
             "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
-            "referenceNumber": 233,
+            "referenceNumber": 602,
             "name": "BitTorrent Open Source License v1.0",
             "licenseId": "BitTorrent-1.0",
             "seeAlso": [
@@ -1011,7 +1084,7 @@
             "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
-            "referenceNumber": 174,
+            "referenceNumber": 161,
             "name": "BitTorrent Open Source License v1.1",
             "licenseId": "BitTorrent-1.1",
             "seeAlso": [
@@ -1024,7 +1097,7 @@
             "reference": "https://spdx.org/licenses/Bitstream-Charter.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Bitstream-Charter.json",
-            "referenceNumber": 47,
+            "referenceNumber": 236,
             "name": "Bitstream Charter Font License",
             "licenseId": "Bitstream-Charter",
             "seeAlso": [
@@ -1037,7 +1110,7 @@
             "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
-            "referenceNumber": 224,
+            "referenceNumber": 421,
             "name": "Bitstream Vera Font License",
             "licenseId": "Bitstream-Vera",
             "seeAlso": [
@@ -1050,19 +1123,19 @@
             "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
-            "referenceNumber": 25,
+            "referenceNumber": 570,
             "name": "Blue Oak Model License 1.0.0",
             "licenseId": "BlueOak-1.0.0",
             "seeAlso": [
                 "https://blueoakcouncil.org/license/1.0.0"
             ],
-            "isOsiApproved": false
+            "isOsiApproved": true
         },
         {
             "reference": "https://spdx.org/licenses/Boehm-GC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Boehm-GC.json",
-            "referenceNumber": 481,
+            "referenceNumber": 15,
             "name": "Boehm-Demers-Weiser GC License",
             "licenseId": "Boehm-GC",
             "seeAlso": [
@@ -1076,7 +1149,7 @@
             "reference": "https://spdx.org/licenses/Borceux.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Borceux.json",
-            "referenceNumber": 443,
+            "referenceNumber": 113,
             "name": "Borceux license",
             "licenseId": "Borceux",
             "seeAlso": [
@@ -1085,10 +1158,23 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/Brian-Gladman-2-Clause.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-2-Clause.json",
+            "referenceNumber": 316,
+            "name": "Brian Gladman 2-Clause License",
+            "licenseId": "Brian-Gladman-2-Clause",
+            "seeAlso": [
+                "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L140-L156",
+                "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause.json",
-            "referenceNumber": 223,
+            "referenceNumber": 444,
             "name": "Brian Gladman 3-Clause License",
             "licenseId": "Brian-Gladman-3-Clause",
             "seeAlso": [
@@ -1100,7 +1186,7 @@
             "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
-            "referenceNumber": 496,
+            "referenceNumber": 551,
             "name": "Computational Use of Data Agreement v1.0",
             "licenseId": "C-UDA-1.0",
             "seeAlso": [
@@ -1113,7 +1199,7 @@
             "reference": "https://spdx.org/licenses/CAL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
-            "referenceNumber": 118,
+            "referenceNumber": 630,
             "name": "Cryptographic Autonomy License 1.0",
             "licenseId": "CAL-1.0",
             "seeAlso": [
@@ -1126,7 +1212,7 @@
             "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
-            "referenceNumber": 139,
+            "referenceNumber": 158,
             "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
             "licenseId": "CAL-1.0-Combined-Work-Exception",
             "seeAlso": [
@@ -1139,7 +1225,7 @@
             "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
-            "referenceNumber": 38,
+            "referenceNumber": 319,
             "name": "Computer Associates Trusted Open Source License 1.1",
             "licenseId": "CATOSL-1.1",
             "seeAlso": [
@@ -1151,7 +1237,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
-            "referenceNumber": 342,
+            "referenceNumber": 384,
             "name": "Creative Commons Attribution 1.0 Generic",
             "licenseId": "CC-BY-1.0",
             "seeAlso": [
@@ -1163,7 +1249,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
-            "referenceNumber": 151,
+            "referenceNumber": 69,
             "name": "Creative Commons Attribution 2.0 Generic",
             "licenseId": "CC-BY-2.0",
             "seeAlso": [
@@ -1175,7 +1261,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
-            "referenceNumber": 562,
+            "referenceNumber": 482,
             "name": "Creative Commons Attribution 2.5 Generic",
             "licenseId": "CC-BY-2.5",
             "seeAlso": [
@@ -1187,7 +1273,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
-            "referenceNumber": 81,
+            "referenceNumber": 348,
             "name": "Creative Commons Attribution 2.5 Australia",
             "licenseId": "CC-BY-2.5-AU",
             "seeAlso": [
@@ -1199,7 +1285,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
-            "referenceNumber": 381,
+            "referenceNumber": 562,
             "name": "Creative Commons Attribution 3.0 Unported",
             "licenseId": "CC-BY-3.0",
             "seeAlso": [
@@ -1211,7 +1297,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
-            "referenceNumber": 354,
+            "referenceNumber": 314,
             "name": "Creative Commons Attribution 3.0 Austria",
             "licenseId": "CC-BY-3.0-AT",
             "seeAlso": [
@@ -1220,10 +1306,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/CC-BY-3.0-AU.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AU.json",
+            "referenceNumber": 235,
+            "name": "Creative Commons Attribution 3.0 Australia",
+            "licenseId": "CC-BY-3.0-AU",
+            "seeAlso": [
+                "https://creativecommons.org/licenses/by/3.0/au/legalcode"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
-            "referenceNumber": 329,
+            "referenceNumber": 110,
             "name": "Creative Commons Attribution 3.0 Germany",
             "licenseId": "CC-BY-3.0-DE",
             "seeAlso": [
@@ -1235,7 +1333,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
-            "referenceNumber": 391,
+            "referenceNumber": 359,
             "name": "Creative Commons Attribution 3.0 IGO",
             "licenseId": "CC-BY-3.0-IGO",
             "seeAlso": [
@@ -1247,7 +1345,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
-            "referenceNumber": 35,
+            "referenceNumber": 130,
             "name": "Creative Commons Attribution 3.0 Netherlands",
             "licenseId": "CC-BY-3.0-NL",
             "seeAlso": [
@@ -1259,7 +1357,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
-            "referenceNumber": 560,
+            "referenceNumber": 38,
             "name": "Creative Commons Attribution 3.0 United States",
             "licenseId": "CC-BY-3.0-US",
             "seeAlso": [
@@ -1271,7 +1369,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
-            "referenceNumber": 53,
+            "referenceNumber": 122,
             "name": "Creative Commons Attribution 4.0 International",
             "licenseId": "CC-BY-4.0",
             "seeAlso": [
@@ -1284,7 +1382,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
-            "referenceNumber": 500,
+            "referenceNumber": 29,
             "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
             "licenseId": "CC-BY-NC-1.0",
             "seeAlso": [
@@ -1297,7 +1395,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
-            "referenceNumber": 155,
+            "referenceNumber": 588,
             "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
             "licenseId": "CC-BY-NC-2.0",
             "seeAlso": [
@@ -1310,7 +1408,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
-            "referenceNumber": 440,
+            "referenceNumber": 400,
             "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
             "licenseId": "CC-BY-NC-2.5",
             "seeAlso": [
@@ -1323,7 +1421,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
-            "referenceNumber": 250,
+            "referenceNumber": 104,
             "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
             "licenseId": "CC-BY-NC-3.0",
             "seeAlso": [
@@ -1336,7 +1434,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
-            "referenceNumber": 317,
+            "referenceNumber": 351,
             "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
             "licenseId": "CC-BY-NC-3.0-DE",
             "seeAlso": [
@@ -1348,7 +1446,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
-            "referenceNumber": 349,
+            "referenceNumber": 353,
             "name": "Creative Commons Attribution Non Commercial 4.0 International",
             "licenseId": "CC-BY-NC-4.0",
             "seeAlso": [
@@ -1361,7 +1459,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-            "referenceNumber": 204,
+            "referenceNumber": 454,
             "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
             "licenseId": "CC-BY-NC-ND-1.0",
             "seeAlso": [
@@ -1373,7 +1471,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-            "referenceNumber": 130,
+            "referenceNumber": 53,
             "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
             "licenseId": "CC-BY-NC-ND-2.0",
             "seeAlso": [
@@ -1385,7 +1483,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-            "referenceNumber": 499,
+            "referenceNumber": 328,
             "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
             "licenseId": "CC-BY-NC-ND-2.5",
             "seeAlso": [
@@ -1397,7 +1495,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-            "referenceNumber": 72,
+            "referenceNumber": 70,
             "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
             "licenseId": "CC-BY-NC-ND-3.0",
             "seeAlso": [
@@ -1409,7 +1507,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
-            "referenceNumber": 423,
+            "referenceNumber": 47,
             "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
             "licenseId": "CC-BY-NC-ND-3.0-DE",
             "seeAlso": [
@@ -1421,7 +1519,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
-            "referenceNumber": 394,
+            "referenceNumber": 213,
             "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
             "licenseId": "CC-BY-NC-ND-3.0-IGO",
             "seeAlso": [
@@ -1433,7 +1531,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-            "referenceNumber": 445,
+            "referenceNumber": 550,
             "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
             "licenseId": "CC-BY-NC-ND-4.0",
             "seeAlso": [
@@ -1445,7 +1543,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-            "referenceNumber": 340,
+            "referenceNumber": 99,
             "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
             "licenseId": "CC-BY-NC-SA-1.0",
             "seeAlso": [
@@ -1457,7 +1555,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-            "referenceNumber": 376,
+            "referenceNumber": 491,
             "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
             "licenseId": "CC-BY-NC-SA-2.0",
             "seeAlso": [
@@ -1469,7 +1567,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.json",
-            "referenceNumber": 40,
+            "referenceNumber": 246,
             "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
             "licenseId": "CC-BY-NC-SA-2.0-DE",
             "seeAlso": [
@@ -1481,7 +1579,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
-            "referenceNumber": 28,
+            "referenceNumber": 368,
             "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
             "licenseId": "CC-BY-NC-SA-2.0-FR",
             "seeAlso": [
@@ -1493,7 +1591,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
-            "referenceNumber": 368,
+            "referenceNumber": 451,
             "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
             "licenseId": "CC-BY-NC-SA-2.0-UK",
             "seeAlso": [
@@ -1505,7 +1603,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-            "referenceNumber": 429,
+            "referenceNumber": 352,
             "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
             "licenseId": "CC-BY-NC-SA-2.5",
             "seeAlso": [
@@ -1517,7 +1615,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-            "referenceNumber": 339,
+            "referenceNumber": 41,
             "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
             "licenseId": "CC-BY-NC-SA-3.0",
             "seeAlso": [
@@ -1529,7 +1627,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
-            "referenceNumber": 462,
+            "referenceNumber": 582,
             "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
             "licenseId": "CC-BY-NC-SA-3.0-DE",
             "seeAlso": [
@@ -1541,7 +1639,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
-            "referenceNumber": 475,
+            "referenceNumber": 205,
             "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
             "licenseId": "CC-BY-NC-SA-3.0-IGO",
             "seeAlso": [
@@ -1553,7 +1651,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-            "referenceNumber": 241,
+            "referenceNumber": 610,
             "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
             "licenseId": "CC-BY-NC-SA-4.0",
             "seeAlso": [
@@ -1565,7 +1663,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
-            "referenceNumber": 550,
+            "referenceNumber": 18,
             "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
             "licenseId": "CC-BY-ND-1.0",
             "seeAlso": [
@@ -1578,7 +1676,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
-            "referenceNumber": 33,
+            "referenceNumber": 614,
             "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
             "licenseId": "CC-BY-ND-2.0",
             "seeAlso": [
@@ -1591,7 +1689,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
-            "referenceNumber": 2,
+            "referenceNumber": 540,
             "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
             "licenseId": "CC-BY-ND-2.5",
             "seeAlso": [
@@ -1604,7 +1702,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
-            "referenceNumber": 80,
+            "referenceNumber": 544,
             "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
             "licenseId": "CC-BY-ND-3.0",
             "seeAlso": [
@@ -1617,7 +1715,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
-            "referenceNumber": 65,
+            "referenceNumber": 355,
             "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
             "licenseId": "CC-BY-ND-3.0-DE",
             "seeAlso": [
@@ -1629,7 +1727,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
-            "referenceNumber": 228,
+            "referenceNumber": 545,
             "name": "Creative Commons Attribution No Derivatives 4.0 International",
             "licenseId": "CC-BY-ND-4.0",
             "seeAlso": [
@@ -1642,7 +1740,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
-            "referenceNumber": 100,
+            "referenceNumber": 242,
             "name": "Creative Commons Attribution Share Alike 1.0 Generic",
             "licenseId": "CC-BY-SA-1.0",
             "seeAlso": [
@@ -1654,7 +1752,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
-            "referenceNumber": 580,
+            "referenceNumber": 349,
             "name": "Creative Commons Attribution Share Alike 2.0 Generic",
             "licenseId": "CC-BY-SA-2.0",
             "seeAlso": [
@@ -1666,7 +1764,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
-            "referenceNumber": 212,
+            "referenceNumber": 197,
             "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
             "licenseId": "CC-BY-SA-2.0-UK",
             "seeAlso": [
@@ -1678,7 +1776,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
-            "referenceNumber": 227,
+            "referenceNumber": 162,
             "name": "Creative Commons Attribution Share Alike 2.1 Japan",
             "licenseId": "CC-BY-SA-2.1-JP",
             "seeAlso": [
@@ -1690,7 +1788,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
-            "referenceNumber": 55,
+            "referenceNumber": 626,
             "name": "Creative Commons Attribution Share Alike 2.5 Generic",
             "licenseId": "CC-BY-SA-2.5",
             "seeAlso": [
@@ -1702,7 +1800,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
-            "referenceNumber": 315,
+            "referenceNumber": 244,
             "name": "Creative Commons Attribution Share Alike 3.0 Unported",
             "licenseId": "CC-BY-SA-3.0",
             "seeAlso": [
@@ -1714,7 +1812,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
-            "referenceNumber": 483,
+            "referenceNumber": 292,
             "name": "Creative Commons Attribution Share Alike 3.0 Austria",
             "licenseId": "CC-BY-SA-3.0-AT",
             "seeAlso": [
@@ -1726,7 +1824,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
-            "referenceNumber": 54,
+            "referenceNumber": 317,
             "name": "Creative Commons Attribution Share Alike 3.0 Germany",
             "licenseId": "CC-BY-SA-3.0-DE",
             "seeAlso": [
@@ -1738,7 +1836,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.json",
-            "referenceNumber": 34,
+            "referenceNumber": 139,
             "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
             "licenseId": "CC-BY-SA-3.0-IGO",
             "seeAlso": [
@@ -1750,7 +1848,7 @@
             "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
-            "referenceNumber": 7,
+            "referenceNumber": 438,
             "name": "Creative Commons Attribution Share Alike 4.0 International",
             "licenseId": "CC-BY-SA-4.0",
             "seeAlso": [
@@ -1763,7 +1861,7 @@
             "reference": "https://spdx.org/licenses/CC-PDDC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
-            "referenceNumber": 186,
+            "referenceNumber": 291,
             "name": "Creative Commons Public Domain Dedication and Certification",
             "licenseId": "CC-PDDC",
             "seeAlso": [
@@ -1775,7 +1873,7 @@
             "reference": "https://spdx.org/licenses/CC0-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
-            "referenceNumber": 414,
+            "referenceNumber": 285,
             "name": "Creative Commons Zero v1.0 Universal",
             "licenseId": "CC0-1.0",
             "seeAlso": [
@@ -1788,7 +1886,7 @@
             "reference": "https://spdx.org/licenses/CDDL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
-            "referenceNumber": 509,
+            "referenceNumber": 154,
             "name": "Common Development and Distribution License 1.0",
             "licenseId": "CDDL-1.0",
             "seeAlso": [
@@ -1801,7 +1899,7 @@
             "reference": "https://spdx.org/licenses/CDDL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
-            "referenceNumber": 113,
+            "referenceNumber": 529,
             "name": "Common Development and Distribution License 1.1",
             "licenseId": "CDDL-1.1",
             "seeAlso": [
@@ -1814,7 +1912,7 @@
             "reference": "https://spdx.org/licenses/CDL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
-            "referenceNumber": 114,
+            "referenceNumber": 243,
             "name": "Common Documentation License 1.0",
             "licenseId": "CDL-1.0",
             "seeAlso": [
@@ -1828,7 +1926,7 @@
             "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
-            "referenceNumber": 474,
+            "referenceNumber": 477,
             "name": "Community Data License Agreement Permissive 1.0",
             "licenseId": "CDLA-Permissive-1.0",
             "seeAlso": [
@@ -1840,7 +1938,7 @@
             "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
-            "referenceNumber": 556,
+            "referenceNumber": 335,
             "name": "Community Data License Agreement Permissive 2.0",
             "licenseId": "CDLA-Permissive-2.0",
             "seeAlso": [
@@ -1852,7 +1950,7 @@
             "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
-            "referenceNumber": 380,
+            "referenceNumber": 548,
             "name": "Community Data License Agreement Sharing 1.0",
             "licenseId": "CDLA-Sharing-1.0",
             "seeAlso": [
@@ -1864,7 +1962,7 @@
             "reference": "https://spdx.org/licenses/CECILL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
-            "referenceNumber": 128,
+            "referenceNumber": 60,
             "name": "CeCILL Free Software License Agreement v1.0",
             "licenseId": "CECILL-1.0",
             "seeAlso": [
@@ -1876,7 +1974,7 @@
             "reference": "https://spdx.org/licenses/CECILL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
-            "referenceNumber": 405,
+            "referenceNumber": 344,
             "name": "CeCILL Free Software License Agreement v1.1",
             "licenseId": "CECILL-1.1",
             "seeAlso": [
@@ -1888,7 +1986,7 @@
             "reference": "https://spdx.org/licenses/CECILL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
-            "referenceNumber": 77,
+            "referenceNumber": 410,
             "name": "CeCILL Free Software License Agreement v2.0",
             "licenseId": "CECILL-2.0",
             "seeAlso": [
@@ -1901,7 +1999,7 @@
             "reference": "https://spdx.org/licenses/CECILL-2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
-            "referenceNumber": 447,
+            "referenceNumber": 174,
             "name": "CeCILL Free Software License Agreement v2.1",
             "licenseId": "CECILL-2.1",
             "seeAlso": [
@@ -1913,7 +2011,7 @@
             "reference": "https://spdx.org/licenses/CECILL-B.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
-            "referenceNumber": 450,
+            "referenceNumber": 256,
             "name": "CeCILL-B Free Software License Agreement",
             "licenseId": "CECILL-B",
             "seeAlso": [
@@ -1926,7 +2024,7 @@
             "reference": "https://spdx.org/licenses/CECILL-C.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
-            "referenceNumber": 415,
+            "referenceNumber": 52,
             "name": "CeCILL-C Free Software License Agreement",
             "licenseId": "CECILL-C",
             "seeAlso": [
@@ -1939,7 +2037,7 @@
             "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
-            "referenceNumber": 296,
+            "referenceNumber": 615,
             "name": "CERN Open Hardware Licence v1.1",
             "licenseId": "CERN-OHL-1.1",
             "seeAlso": [
@@ -1951,7 +2049,7 @@
             "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
-            "referenceNumber": 61,
+            "referenceNumber": 324,
             "name": "CERN Open Hardware Licence v1.2",
             "licenseId": "CERN-OHL-1.2",
             "seeAlso": [
@@ -1963,7 +2061,7 @@
             "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
-            "referenceNumber": 103,
+            "referenceNumber": 402,
             "name": "CERN Open Hardware Licence Version 2 - Permissive",
             "licenseId": "CERN-OHL-P-2.0",
             "seeAlso": [
@@ -1975,7 +2073,7 @@
             "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
-            "referenceNumber": 67,
+            "referenceNumber": 513,
             "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
             "licenseId": "CERN-OHL-S-2.0",
             "seeAlso": [
@@ -1987,7 +2085,7 @@
             "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
-            "referenceNumber": 438,
+            "referenceNumber": 237,
             "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
             "licenseId": "CERN-OHL-W-2.0",
             "seeAlso": [
@@ -1999,7 +2097,7 @@
             "reference": "https://spdx.org/licenses/CFITSIO.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CFITSIO.json",
-            "referenceNumber": 30,
+            "referenceNumber": 151,
             "name": "CFITSIO License",
             "licenseId": "CFITSIO",
             "seeAlso": [
@@ -2012,7 +2110,7 @@
             "reference": "https://spdx.org/licenses/CMU-Mach.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CMU-Mach.json",
-            "referenceNumber": 383,
+            "referenceNumber": 492,
             "name": "CMU Mach License",
             "licenseId": "CMU-Mach",
             "seeAlso": [
@@ -2021,10 +2119,23 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/CMU-Mach-nodoc.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/CMU-Mach-nodoc.json",
+            "referenceNumber": 318,
+            "name": "CMU    Mach - no notices-in-documentation variant",
+            "licenseId": "CMU-Mach-nodoc",
+            "seeAlso": [
+                "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L718-L728",
+                "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/CNRI-Jython.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
-            "referenceNumber": 541,
+            "referenceNumber": 203,
             "name": "CNRI Jython License",
             "licenseId": "CNRI-Jython",
             "seeAlso": [
@@ -2036,7 +2147,7 @@
             "reference": "https://spdx.org/licenses/CNRI-Python.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
-            "referenceNumber": 388,
+            "referenceNumber": 218,
             "name": "CNRI Python License",
             "licenseId": "CNRI-Python",
             "seeAlso": [
@@ -2048,7 +2159,7 @@
             "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-            "referenceNumber": 473,
+            "referenceNumber": 391,
             "name": "CNRI Python Open Source GPL Compatible License Agreement",
             "licenseId": "CNRI-Python-GPL-Compatible",
             "seeAlso": [
@@ -2060,7 +2171,7 @@
             "reference": "https://spdx.org/licenses/COIL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
-            "referenceNumber": 542,
+            "referenceNumber": 375,
             "name": "Copyfree Open Innovation License",
             "licenseId": "COIL-1.0",
             "seeAlso": [
@@ -2072,7 +2183,7 @@
             "reference": "https://spdx.org/licenses/CPAL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
-            "referenceNumber": 373,
+            "referenceNumber": 223,
             "name": "Common Public Attribution License 1.0",
             "licenseId": "CPAL-1.0",
             "seeAlso": [
@@ -2085,7 +2196,7 @@
             "reference": "https://spdx.org/licenses/CPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
-            "referenceNumber": 457,
+            "referenceNumber": 181,
             "name": "Common Public License 1.0",
             "licenseId": "CPL-1.0",
             "seeAlso": [
@@ -2098,7 +2209,7 @@
             "reference": "https://spdx.org/licenses/CPOL-1.02.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
-            "referenceNumber": 488,
+            "referenceNumber": 176,
             "name": "Code Project Open License 1.02",
             "licenseId": "CPOL-1.02",
             "seeAlso": [
@@ -2111,7 +2222,7 @@
             "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
-            "referenceNumber": 216,
+            "referenceNumber": 313,
             "name": "CUA Office Public License v1.0",
             "licenseId": "CUA-OPL-1.0",
             "seeAlso": [
@@ -2123,7 +2234,7 @@
             "reference": "https://spdx.org/licenses/Caldera.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Caldera.json",
-            "referenceNumber": 334,
+            "referenceNumber": 282,
             "name": "Caldera License",
             "licenseId": "Caldera",
             "seeAlso": [
@@ -2132,10 +2243,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/Caldera-no-preamble.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Caldera-no-preamble.json",
+            "referenceNumber": 262,
+            "name": "Caldera License (without preamble)",
+            "licenseId": "Caldera-no-preamble",
+            "seeAlso": [
+                "https://github.com/apache/apr/blob/trunk/LICENSE#L298C6-L298C29"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/ClArtistic.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
-            "referenceNumber": 49,
+            "referenceNumber": 441,
             "name": "Clarified Artistic License",
             "licenseId": "ClArtistic",
             "seeAlso": [
@@ -2149,7 +2272,7 @@
             "reference": "https://spdx.org/licenses/Clips.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Clips.json",
-            "referenceNumber": 92,
+            "referenceNumber": 167,
             "name": "Clips License",
             "licenseId": "Clips",
             "seeAlso": [
@@ -2161,7 +2284,7 @@
             "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
-            "referenceNumber": 218,
+            "referenceNumber": 357,
             "name": "Community Specification License 1.0",
             "licenseId": "Community-Spec-1.0",
             "seeAlso": [
@@ -2173,7 +2296,7 @@
             "reference": "https://spdx.org/licenses/Condor-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
-            "referenceNumber": 563,
+            "referenceNumber": 385,
             "name": "Condor Public License v1.1",
             "licenseId": "Condor-1.1",
             "seeAlso": [
@@ -2187,7 +2310,7 @@
             "reference": "https://spdx.org/licenses/Cornell-Lossless-JPEG.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Cornell-Lossless-JPEG.json",
-            "referenceNumber": 277,
+            "referenceNumber": 542,
             "name": "Cornell Lossless JPEG License",
             "licenseId": "Cornell-Lossless-JPEG",
             "seeAlso": [
@@ -2201,7 +2324,7 @@
             "reference": "https://spdx.org/licenses/Cronyx.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Cronyx.json",
-            "referenceNumber": 120,
+            "referenceNumber": 303,
             "name": "Cronyx License",
             "licenseId": "Cronyx",
             "seeAlso": [
@@ -2216,7 +2339,7 @@
             "reference": "https://spdx.org/licenses/Crossword.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Crossword.json",
-            "referenceNumber": 321,
+            "referenceNumber": 304,
             "name": "Crossword License",
             "licenseId": "Crossword",
             "seeAlso": [
@@ -2228,7 +2351,7 @@
             "reference": "https://spdx.org/licenses/CrystalStacker.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
-            "referenceNumber": 498,
+            "referenceNumber": 522,
             "name": "CrystalStacker License",
             "licenseId": "CrystalStacker",
             "seeAlso": [
@@ -2240,7 +2363,7 @@
             "reference": "https://spdx.org/licenses/Cube.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Cube.json",
-            "referenceNumber": 460,
+            "referenceNumber": 126,
             "name": "Cube License",
             "licenseId": "Cube",
             "seeAlso": [
@@ -2252,7 +2375,7 @@
             "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
-            "referenceNumber": 206,
+            "referenceNumber": 31,
             "name": "Deutsche Freie Software Lizenz",
             "licenseId": "D-FSL-1.0",
             "seeAlso": [
@@ -2268,10 +2391,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/DEC-3-Clause.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/DEC-3-Clause.json",
+            "referenceNumber": 620,
+            "name": "DEC 3-Clause License",
+            "licenseId": "DEC-3-Clause",
+            "seeAlso": [
+                "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type=heads#L239"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
-            "referenceNumber": 516,
+            "referenceNumber": 363,
             "name": "Data licence Germany \u2013 attribution \u2013 version 2.0",
             "licenseId": "DL-DE-BY-2.0",
             "seeAlso": [
@@ -2283,7 +2418,7 @@
             "reference": "https://spdx.org/licenses/DL-DE-ZERO-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/DL-DE-ZERO-2.0.json",
-            "referenceNumber": 178,
+            "referenceNumber": 497,
             "name": "Data licence Germany \u2013 zero \u2013 version 2.0",
             "licenseId": "DL-DE-ZERO-2.0",
             "seeAlso": [
@@ -2295,7 +2430,7 @@
             "reference": "https://spdx.org/licenses/DOC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/DOC.json",
-            "referenceNumber": 68,
+            "referenceNumber": 82,
             "name": "DOC License",
             "licenseId": "DOC",
             "seeAlso": [
@@ -2308,7 +2443,7 @@
             "reference": "https://spdx.org/licenses/DRL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
-            "referenceNumber": 4,
+            "referenceNumber": 623,
             "name": "Detection Rule License 1.0",
             "licenseId": "DRL-1.0",
             "seeAlso": [
@@ -2317,10 +2452,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/DRL-1.1.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/DRL-1.1.json",
+            "referenceNumber": 259,
+            "name": "Detection Rule License 1.1",
+            "licenseId": "DRL-1.1",
+            "seeAlso": [
+                "https://github.com/SigmaHQ/Detection-Rule-License/blob/6ec7fbde6101d101b5b5d1fcb8f9b69fbc76c04a/LICENSE.Detection.Rules.md"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/DSDP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/DSDP.json",
-            "referenceNumber": 205,
+            "referenceNumber": 549,
             "name": "DSDP License",
             "licenseId": "DSDP",
             "seeAlso": [
@@ -2332,7 +2479,7 @@
             "reference": "https://spdx.org/licenses/Dotseqn.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
-            "referenceNumber": 534,
+            "referenceNumber": 148,
             "name": "Dotseqn License",
             "licenseId": "Dotseqn",
             "seeAlso": [
@@ -2344,7 +2491,7 @@
             "reference": "https://spdx.org/licenses/ECL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
-            "referenceNumber": 23,
+            "referenceNumber": 40,
             "name": "Educational Community License v1.0",
             "licenseId": "ECL-1.0",
             "seeAlso": [
@@ -2356,7 +2503,7 @@
             "reference": "https://spdx.org/licenses/ECL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
-            "referenceNumber": 519,
+            "referenceNumber": 224,
             "name": "Educational Community License v2.0",
             "licenseId": "ECL-2.0",
             "seeAlso": [
@@ -2369,7 +2516,7 @@
             "reference": "https://spdx.org/licenses/EFL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
-            "referenceNumber": 324,
+            "referenceNumber": 329,
             "name": "Eiffel Forum License v1.0",
             "licenseId": "EFL-1.0",
             "seeAlso": [
@@ -2382,7 +2529,7 @@
             "reference": "https://spdx.org/licenses/EFL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
-            "referenceNumber": 458,
+            "referenceNumber": 535,
             "name": "Eiffel Forum License v2.0",
             "licenseId": "EFL-2.0",
             "seeAlso": [
@@ -2396,7 +2543,7 @@
             "reference": "https://spdx.org/licenses/EPICS.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EPICS.json",
-            "referenceNumber": 454,
+            "referenceNumber": 523,
             "name": "EPICS Open License",
             "licenseId": "EPICS",
             "seeAlso": [
@@ -2408,7 +2555,7 @@
             "reference": "https://spdx.org/licenses/EPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
-            "referenceNumber": 281,
+            "referenceNumber": 229,
             "name": "Eclipse Public License 1.0",
             "licenseId": "EPL-1.0",
             "seeAlso": [
@@ -2422,7 +2569,7 @@
             "reference": "https://spdx.org/licenses/EPL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
-            "referenceNumber": 197,
+            "referenceNumber": 143,
             "name": "Eclipse Public License 2.0",
             "licenseId": "EPL-2.0",
             "seeAlso": [
@@ -2436,7 +2583,7 @@
             "reference": "https://spdx.org/licenses/EUDatagrid.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
-            "referenceNumber": 302,
+            "referenceNumber": 191,
             "name": "EU DataGrid Software License",
             "licenseId": "EUDatagrid",
             "seeAlso": [
@@ -2450,7 +2597,7 @@
             "reference": "https://spdx.org/licenses/EUPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
-            "referenceNumber": 168,
+            "referenceNumber": 392,
             "name": "European Union Public License 1.0",
             "licenseId": "EUPL-1.0",
             "seeAlso": [
@@ -2463,7 +2610,7 @@
             "reference": "https://spdx.org/licenses/EUPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
-            "referenceNumber": 330,
+            "referenceNumber": 26,
             "name": "European Union Public License 1.1",
             "licenseId": "EUPL-1.1",
             "seeAlso": [
@@ -2478,7 +2625,7 @@
             "reference": "https://spdx.org/licenses/EUPL-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
-            "referenceNumber": 116,
+            "referenceNumber": 34,
             "name": "European Union Public License 1.2",
             "licenseId": "EUPL-1.2",
             "seeAlso": [
@@ -2496,7 +2643,7 @@
             "reference": "https://spdx.org/licenses/Elastic-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
-            "referenceNumber": 551,
+            "referenceNumber": 21,
             "name": "Elastic License 2.0",
             "licenseId": "Elastic-2.0",
             "seeAlso": [
@@ -2509,7 +2656,7 @@
             "reference": "https://spdx.org/licenses/Entessa.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Entessa.json",
-            "referenceNumber": 387,
+            "referenceNumber": 87,
             "name": "Entessa Public License v1.0",
             "licenseId": "Entessa",
             "seeAlso": [
@@ -2521,7 +2668,7 @@
             "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
-            "referenceNumber": 441,
+            "referenceNumber": 592,
             "name": "Erlang Public License v1.1",
             "licenseId": "ErlPL-1.1",
             "seeAlso": [
@@ -2533,7 +2680,7 @@
             "reference": "https://spdx.org/licenses/Eurosym.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
-            "referenceNumber": 366,
+            "referenceNumber": 584,
             "name": "Eurosym License",
             "licenseId": "Eurosym",
             "seeAlso": [
@@ -2545,7 +2692,7 @@
             "reference": "https://spdx.org/licenses/FBM.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FBM.json",
-            "referenceNumber": 552,
+            "referenceNumber": 227,
             "name": "Fuzzy Bitmap License",
             "licenseId": "FBM",
             "seeAlso": [
@@ -2557,7 +2704,7 @@
             "reference": "https://spdx.org/licenses/FDK-AAC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
-            "referenceNumber": 124,
+            "referenceNumber": 323,
             "name": "Fraunhofer FDK AAC Codec Library",
             "licenseId": "FDK-AAC",
             "seeAlso": [
@@ -2570,7 +2717,7 @@
             "reference": "https://spdx.org/licenses/FSFAP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
-            "referenceNumber": 543,
+            "referenceNumber": 273,
             "name": "FSF All Permissive License",
             "licenseId": "FSFAP",
             "seeAlso": [
@@ -2580,10 +2727,22 @@
             "isFsfLibre": true
         },
         {
+            "reference": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.json",
+            "referenceNumber": 67,
+            "name": "FSF All Permissive License (without Warranty)",
+            "licenseId": "FSFAP-no-warranty-disclaimer",
+            "seeAlso": [
+                "https://git.savannah.gnu.org/cgit/wget.git/tree/util/trunc.c?h=v1.21.3&id=40747a11e44ced5a8ac628a41f879ced3e2ebce9#n6"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/FSFUL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
-            "referenceNumber": 36,
+            "referenceNumber": 577,
             "name": "FSF Unlimited License",
             "licenseId": "FSFUL",
             "seeAlso": [
@@ -2595,7 +2754,7 @@
             "reference": "https://spdx.org/licenses/FSFULLR.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
-            "referenceNumber": 52,
+            "referenceNumber": 96,
             "name": "FSF Unlimited License (with License Retention)",
             "licenseId": "FSFULLR",
             "seeAlso": [
@@ -2607,7 +2766,7 @@
             "reference": "https://spdx.org/licenses/FSFULLRWD.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FSFULLRWD.json",
-            "referenceNumber": 468,
+            "referenceNumber": 456,
             "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
             "licenseId": "FSFULLRWD",
             "seeAlso": [
@@ -2619,7 +2778,7 @@
             "reference": "https://spdx.org/licenses/FTL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FTL.json",
-            "referenceNumber": 584,
+            "referenceNumber": 519,
             "name": "Freetype Project License",
             "licenseId": "FTL",
             "seeAlso": [
@@ -2634,11 +2793,11 @@
             "reference": "https://spdx.org/licenses/Fair.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Fair.json",
-            "referenceNumber": 267,
+            "referenceNumber": 93,
             "name": "Fair License",
             "licenseId": "Fair",
             "seeAlso": [
-                "http://fairlicense.org/",
+                "https://web.archive.org/web/20150926120323/http://fairlicense.org/",
                 "https://opensource.org/licenses/Fair"
             ],
             "isOsiApproved": true
@@ -2647,7 +2806,7 @@
             "reference": "https://spdx.org/licenses/Ferguson-Twofish.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Ferguson-Twofish.json",
-            "referenceNumber": 260,
+            "referenceNumber": 447,
             "name": "Ferguson Twofish License",
             "licenseId": "Ferguson-Twofish",
             "seeAlso": [
@@ -2659,7 +2818,7 @@
             "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
-            "referenceNumber": 478,
+            "referenceNumber": 152,
             "name": "Frameworx Open License 1.0",
             "licenseId": "Frameworx-1.0",
             "seeAlso": [
@@ -2671,7 +2830,7 @@
             "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
-            "referenceNumber": 422,
+            "referenceNumber": 73,
             "name": "FreeBSD Documentation License",
             "licenseId": "FreeBSD-DOC",
             "seeAlso": [
@@ -2683,7 +2842,7 @@
             "reference": "https://spdx.org/licenses/FreeImage.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
-            "referenceNumber": 60,
+            "referenceNumber": 131,
             "name": "FreeImage Public License v1.0",
             "licenseId": "FreeImage",
             "seeAlso": [
@@ -2695,7 +2854,7 @@
             "reference": "https://spdx.org/licenses/Furuseth.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Furuseth.json",
-            "referenceNumber": 416,
+            "referenceNumber": 604,
             "name": "Furuseth License",
             "licenseId": "Furuseth",
             "seeAlso": [
@@ -2704,10 +2863,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/GCR-docs.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/GCR-docs.json",
+            "referenceNumber": 155,
+            "name": "Gnome GCR Documentation License",
+            "licenseId": "GCR-docs",
+            "seeAlso": [
+                "https://github.com/GNOME/gcr/blob/master/docs/COPYING"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/GD.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GD.json",
-            "referenceNumber": 243,
+            "referenceNumber": 92,
             "name": "GD License",
             "licenseId": "GD",
             "seeAlso": [
@@ -2719,7 +2890,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.1.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
-            "referenceNumber": 337,
+            "referenceNumber": 195,
             "name": "GNU Free Documentation License v1.1",
             "licenseId": "GFDL-1.1",
             "seeAlso": [
@@ -2732,7 +2903,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
-            "referenceNumber": 202,
+            "referenceNumber": 346,
             "name": "GNU Free Documentation License v1.1 only - invariants",
             "licenseId": "GFDL-1.1-invariants-only",
             "seeAlso": [
@@ -2744,7 +2915,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
-            "referenceNumber": 356,
+            "referenceNumber": 269,
             "name": "GNU Free Documentation License v1.1 or later - invariants",
             "licenseId": "GFDL-1.1-invariants-or-later",
             "seeAlso": [
@@ -2756,7 +2927,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
-            "referenceNumber": 144,
+            "referenceNumber": 6,
             "name": "GNU Free Documentation License v1.1 only - no invariants",
             "licenseId": "GFDL-1.1-no-invariants-only",
             "seeAlso": [
@@ -2768,7 +2939,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
-            "referenceNumber": 310,
+            "referenceNumber": 7,
             "name": "GNU Free Documentation License v1.1 or later - no invariants",
             "licenseId": "GFDL-1.1-no-invariants-or-later",
             "seeAlso": [
@@ -2780,7 +2951,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
-            "referenceNumber": 291,
+            "referenceNumber": 264,
             "name": "GNU Free Documentation License v1.1 only",
             "licenseId": "GFDL-1.1-only",
             "seeAlso": [
@@ -2793,7 +2964,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
-            "referenceNumber": 121,
+            "referenceNumber": 196,
             "name": "GNU Free Documentation License v1.1 or later",
             "licenseId": "GFDL-1.1-or-later",
             "seeAlso": [
@@ -2806,7 +2977,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.2.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
-            "referenceNumber": 431,
+            "referenceNumber": 97,
             "name": "GNU Free Documentation License v1.2",
             "licenseId": "GFDL-1.2",
             "seeAlso": [
@@ -2819,7 +2990,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
-            "referenceNumber": 501,
+            "referenceNumber": 611,
             "name": "GNU Free Documentation License v1.2 only - invariants",
             "licenseId": "GFDL-1.2-invariants-only",
             "seeAlso": [
@@ -2831,7 +3002,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
-            "referenceNumber": 238,
+            "referenceNumber": 464,
             "name": "GNU Free Documentation License v1.2 or later - invariants",
             "licenseId": "GFDL-1.2-invariants-or-later",
             "seeAlso": [
@@ -2843,7 +3014,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
-            "referenceNumber": 158,
+            "referenceNumber": 75,
             "name": "GNU Free Documentation License v1.2 only - no invariants",
             "licenseId": "GFDL-1.2-no-invariants-only",
             "seeAlso": [
@@ -2855,7 +3026,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
-            "referenceNumber": 253,
+            "referenceNumber": 14,
             "name": "GNU Free Documentation License v1.2 or later - no invariants",
             "licenseId": "GFDL-1.2-no-invariants-or-later",
             "seeAlso": [
@@ -2867,7 +3038,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
-            "referenceNumber": 71,
+            "referenceNumber": 322,
             "name": "GNU Free Documentation License v1.2 only",
             "licenseId": "GFDL-1.2-only",
             "seeAlso": [
@@ -2880,7 +3051,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
-            "referenceNumber": 12,
+            "referenceNumber": 594,
             "name": "GNU Free Documentation License v1.2 or later",
             "licenseId": "GFDL-1.2-or-later",
             "seeAlso": [
@@ -2893,7 +3064,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.3.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
-            "referenceNumber": 574,
+            "referenceNumber": 538,
             "name": "GNU Free Documentation License v1.3",
             "licenseId": "GFDL-1.3",
             "seeAlso": [
@@ -2906,7 +3077,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
-            "referenceNumber": 157,
+            "referenceNumber": 571,
             "name": "GNU Free Documentation License v1.3 only - invariants",
             "licenseId": "GFDL-1.3-invariants-only",
             "seeAlso": [
@@ -2918,7 +3089,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
-            "referenceNumber": 29,
+            "referenceNumber": 300,
             "name": "GNU Free Documentation License v1.3 or later - invariants",
             "licenseId": "GFDL-1.3-invariants-or-later",
             "seeAlso": [
@@ -2930,7 +3101,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
-            "referenceNumber": 455,
+            "referenceNumber": 101,
             "name": "GNU Free Documentation License v1.3 only - no invariants",
             "licenseId": "GFDL-1.3-no-invariants-only",
             "seeAlso": [
@@ -2942,7 +3113,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
-            "referenceNumber": 512,
+            "referenceNumber": 330,
             "name": "GNU Free Documentation License v1.3 or later - no invariants",
             "licenseId": "GFDL-1.3-no-invariants-or-later",
             "seeAlso": [
@@ -2954,7 +3125,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
-            "referenceNumber": 439,
+            "referenceNumber": 457,
             "name": "GNU Free Documentation License v1.3 only",
             "licenseId": "GFDL-1.3-only",
             "seeAlso": [
@@ -2967,7 +3138,7 @@
             "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
-            "referenceNumber": 295,
+            "referenceNumber": 472,
             "name": "GNU Free Documentation License v1.3 or later",
             "licenseId": "GFDL-1.3-or-later",
             "seeAlso": [
@@ -2980,7 +3151,7 @@
             "reference": "https://spdx.org/licenses/GL2PS.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
-            "referenceNumber": 69,
+            "referenceNumber": 338,
             "name": "GL2PS License",
             "licenseId": "GL2PS",
             "seeAlso": [
@@ -2992,7 +3163,7 @@
             "reference": "https://spdx.org/licenses/GLWTPL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
-            "referenceNumber": 107,
+            "referenceNumber": 576,
             "name": "Good Luck With That Public License",
             "licenseId": "GLWTPL",
             "seeAlso": [
@@ -3004,7 +3175,7 @@
             "reference": "https://spdx.org/licenses/GPL-1.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
-            "referenceNumber": 97,
+            "referenceNumber": 601,
             "name": "GNU General Public License v1.0 only",
             "licenseId": "GPL-1.0",
             "seeAlso": [
@@ -3016,7 +3187,7 @@
             "reference": "https://spdx.org/licenses/GPL-1.0+.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
-            "referenceNumber": 175,
+            "referenceNumber": 442,
             "name": "GNU General Public License v1.0 or later",
             "licenseId": "GPL-1.0+",
             "seeAlso": [
@@ -3028,7 +3199,7 @@
             "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
-            "referenceNumber": 31,
+            "referenceNumber": 527,
             "name": "GNU General Public License v1.0 only",
             "licenseId": "GPL-1.0-only",
             "seeAlso": [
@@ -3040,7 +3211,7 @@
             "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
-            "referenceNumber": 269,
+            "referenceNumber": 0,
             "name": "GNU General Public License v1.0 or later",
             "licenseId": "GPL-1.0-or-later",
             "seeAlso": [
@@ -3052,7 +3223,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
-            "referenceNumber": 335,
+            "referenceNumber": 473,
             "name": "GNU General Public License v2.0 only",
             "licenseId": "GPL-2.0",
             "seeAlso": [
@@ -3066,7 +3237,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0+.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
-            "referenceNumber": 44,
+            "referenceNumber": 502,
             "name": "GNU General Public License v2.0 or later",
             "licenseId": "GPL-2.0+",
             "seeAlso": [
@@ -3080,11 +3251,12 @@
             "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
-            "referenceNumber": 87,
+            "referenceNumber": 404,
             "name": "GNU General Public License v2.0 only",
             "licenseId": "GPL-2.0-only",
             "seeAlso": [
                 "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+                "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt",
                 "https://opensource.org/licenses/GPL-2.0"
             ],
             "isOsiApproved": true,
@@ -3094,7 +3266,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
-            "referenceNumber": 538,
+            "referenceNumber": 389,
             "name": "GNU General Public License v2.0 or later",
             "licenseId": "GPL-2.0-or-later",
             "seeAlso": [
@@ -3108,7 +3280,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-            "referenceNumber": 476,
+            "referenceNumber": 54,
             "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
             "licenseId": "GPL-2.0-with-GCC-exception",
             "seeAlso": [
@@ -3120,7 +3292,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-            "referenceNumber": 140,
+            "referenceNumber": 333,
             "name": "GNU General Public License v2.0 w/Autoconf exception",
             "licenseId": "GPL-2.0-with-autoconf-exception",
             "seeAlso": [
@@ -3132,7 +3304,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-            "referenceNumber": 280,
+            "referenceNumber": 117,
             "name": "GNU General Public License v2.0 w/Bison exception",
             "licenseId": "GPL-2.0-with-bison-exception",
             "seeAlso": [
@@ -3144,7 +3316,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-            "referenceNumber": 452,
+            "referenceNumber": 144,
             "name": "GNU General Public License v2.0 w/Classpath exception",
             "licenseId": "GPL-2.0-with-classpath-exception",
             "seeAlso": [
@@ -3156,7 +3328,7 @@
             "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-            "referenceNumber": 332,
+            "referenceNumber": 286,
             "name": "GNU General Public License v2.0 w/Font exception",
             "licenseId": "GPL-2.0-with-font-exception",
             "seeAlso": [
@@ -3168,7 +3340,7 @@
             "reference": "https://spdx.org/licenses/GPL-3.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
-            "referenceNumber": 15,
+            "referenceNumber": 233,
             "name": "GNU General Public License v3.0 only",
             "licenseId": "GPL-3.0",
             "seeAlso": [
@@ -3182,7 +3354,7 @@
             "reference": "https://spdx.org/licenses/GPL-3.0+.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
-            "referenceNumber": 196,
+            "referenceNumber": 201,
             "name": "GNU General Public License v3.0 or later",
             "licenseId": "GPL-3.0+",
             "seeAlso": [
@@ -3196,7 +3368,7 @@
             "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
-            "referenceNumber": 314,
+            "referenceNumber": 339,
             "name": "GNU General Public License v3.0 only",
             "licenseId": "GPL-3.0-only",
             "seeAlso": [
@@ -3210,7 +3382,7 @@
             "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
-            "referenceNumber": 557,
+            "referenceNumber": 109,
             "name": "GNU General Public License v3.0 or later",
             "licenseId": "GPL-3.0-or-later",
             "seeAlso": [
@@ -3224,7 +3396,7 @@
             "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-            "referenceNumber": 491,
+            "referenceNumber": 331,
             "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
             "licenseId": "GPL-3.0-with-GCC-exception",
             "seeAlso": [
@@ -3236,7 +3408,7 @@
             "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-            "referenceNumber": 184,
+            "referenceNumber": 121,
             "name": "GNU General Public License v3.0 w/Autoconf exception",
             "licenseId": "GPL-3.0-with-autoconf-exception",
             "seeAlso": [
@@ -3248,7 +3420,7 @@
             "reference": "https://spdx.org/licenses/Giftware.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Giftware.json",
-            "referenceNumber": 255,
+            "referenceNumber": 449,
             "name": "Giftware License",
             "licenseId": "Giftware",
             "seeAlso": [
@@ -3260,7 +3432,7 @@
             "reference": "https://spdx.org/licenses/Glide.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Glide.json",
-            "referenceNumber": 578,
+            "referenceNumber": 215,
             "name": "3dfx Glide License",
             "licenseId": "Glide",
             "seeAlso": [
@@ -3272,7 +3444,7 @@
             "reference": "https://spdx.org/licenses/Glulxe.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
-            "referenceNumber": 265,
+            "referenceNumber": 289,
             "name": "Glulxe License",
             "licenseId": "Glulxe",
             "seeAlso": [
@@ -3284,7 +3456,7 @@
             "reference": "https://spdx.org/licenses/Graphics-Gems.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Graphics-Gems.json",
-            "referenceNumber": 242,
+            "referenceNumber": 68,
             "name": "Graphics Gems License",
             "licenseId": "Graphics-Gems",
             "seeAlso": [
@@ -3296,7 +3468,7 @@
             "reference": "https://spdx.org/licenses/HP-1986.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HP-1986.json",
-            "referenceNumber": 290,
+            "referenceNumber": 39,
             "name": "Hewlett-Packard 1986 License",
             "licenseId": "HP-1986",
             "seeAlso": [
@@ -3308,7 +3480,7 @@
             "reference": "https://spdx.org/licenses/HP-1989.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HP-1989.json",
-            "referenceNumber": 234,
+            "referenceNumber": 578,
             "name": "Hewlett-Packard 1989 License",
             "licenseId": "HP-1989",
             "seeAlso": [
@@ -3320,7 +3492,7 @@
             "reference": "https://spdx.org/licenses/HPND.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND.json",
-            "referenceNumber": 323,
+            "referenceNumber": 624,
             "name": "Historical Permission Notice and Disclaimer",
             "licenseId": "HPND",
             "seeAlso": [
@@ -3334,7 +3506,7 @@
             "reference": "https://spdx.org/licenses/HPND-DEC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-DEC.json",
-            "referenceNumber": 289,
+            "referenceNumber": 115,
             "name": "Historical Permission Notice and Disclaimer - DEC variant",
             "licenseId": "HPND-DEC",
             "seeAlso": [
@@ -3343,10 +3515,59 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.json",
+            "referenceNumber": 305,
+            "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
+            "licenseId": "HPND-Fenneberg-Livingston",
+            "seeAlso": [
+                "https://github.com/FreeRADIUS/freeradius-client/blob/master/COPYRIGHT#L32",
+                "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L34"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/HPND-INRIA-IMAG.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/HPND-INRIA-IMAG.json",
+            "referenceNumber": 10,
+            "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
+            "licenseId": "HPND-INRIA-IMAG",
+            "seeAlso": [
+                "https://github.com/ppp-project/ppp/blob/master/pppd/ipv6cp.c#L75-L83"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/HPND-Kevlin-Henney.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/HPND-Kevlin-Henney.json",
+            "referenceNumber": 462,
+            "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
+            "licenseId": "HPND-Kevlin-Henney",
+            "seeAlso": [
+                "https://github.com/mruby/mruby/blob/83d12f8d52522cdb7c8cc46fad34821359f453e6/mrbgems/mruby-dir/src/Win/dirent.c#L127-L140"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/HPND-MIT-disclaimer.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/HPND-MIT-disclaimer.json",
+            "referenceNumber": 345,
+            "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
+            "licenseId": "HPND-MIT-disclaimer",
+            "seeAlso": [
+                "https://metacpan.org/release/NLNETLABS/Net-DNS-SEC-1.22/source/LICENSE"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/HPND-Markus-Kuhn.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-Markus-Kuhn.json",
-            "referenceNumber": 393,
+            "referenceNumber": 367,
             "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
             "licenseId": "HPND-Markus-Kuhn",
             "seeAlso": [
@@ -3359,7 +3580,7 @@
             "reference": "https://spdx.org/licenses/HPND-Pbmplus.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-Pbmplus.json",
-            "referenceNumber": 504,
+            "referenceNumber": 204,
             "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
             "licenseId": "HPND-Pbmplus",
             "seeAlso": [
@@ -3371,7 +3592,7 @@
             "reference": "https://spdx.org/licenses/HPND-UC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-UC.json",
-            "referenceNumber": 390,
+            "referenceNumber": 107,
             "name": "Historical Permission Notice and Disclaimer - University of California variant",
             "licenseId": "HPND-UC",
             "seeAlso": [
@@ -3383,7 +3604,7 @@
             "reference": "https://spdx.org/licenses/HPND-doc.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-doc.json",
-            "referenceNumber": 85,
+            "referenceNumber": 30,
             "name": "Historical Permission Notice and Disclaimer - documentation variant",
             "licenseId": "HPND-doc",
             "seeAlso": [
@@ -3396,7 +3617,7 @@
             "reference": "https://spdx.org/licenses/HPND-doc-sell.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-doc-sell.json",
-            "referenceNumber": 232,
+            "referenceNumber": 184,
             "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
             "licenseId": "HPND-doc-sell",
             "seeAlso": [
@@ -3409,7 +3630,7 @@
             "reference": "https://spdx.org/licenses/HPND-export-US.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-export-US.json",
-            "referenceNumber": 37,
+            "referenceNumber": 336,
             "name": "HPND with US Government export control warning",
             "licenseId": "HPND-export-US",
             "seeAlso": [
@@ -3421,7 +3642,7 @@
             "reference": "https://spdx.org/licenses/HPND-export-US-modify.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-export-US-modify.json",
-            "referenceNumber": 532,
+            "referenceNumber": 261,
             "name": "HPND with US Government export control warning and modification rqmt",
             "licenseId": "HPND-export-US-modify",
             "seeAlso": [
@@ -3431,10 +3652,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.json",
+            "referenceNumber": 532,
+            "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
+            "licenseId": "HPND-sell-MIT-disclaimer-xserver",
+            "seeAlso": [
+                "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type=heads#L1781"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/HPND-sell-regexpr.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-sell-regexpr.json",
-            "referenceNumber": 461,
+            "referenceNumber": 572,
             "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
             "licenseId": "HPND-sell-regexpr",
             "seeAlso": [
@@ -3446,7 +3679,7 @@
             "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
-            "referenceNumber": 540,
+            "referenceNumber": 414,
             "name": "Historical Permission Notice and Disclaimer - sell variant",
             "licenseId": "HPND-sell-variant",
             "seeAlso": [
@@ -3458,7 +3691,7 @@
             "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.json",
-            "referenceNumber": 502,
+            "referenceNumber": 51,
             "name": "HPND sell variant with MIT disclaimer",
             "licenseId": "HPND-sell-variant-MIT-disclaimer",
             "seeAlso": [
@@ -3470,7 +3703,7 @@
             "reference": "https://spdx.org/licenses/HTMLTIDY.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
-            "referenceNumber": 252,
+            "referenceNumber": 474,
             "name": "HTML Tidy License",
             "licenseId": "HTMLTIDY",
             "seeAlso": [
@@ -3482,7 +3715,7 @@
             "reference": "https://spdx.org/licenses/HaskellReport.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
-            "referenceNumber": 581,
+            "referenceNumber": 138,
             "name": "Haskell Language Report License",
             "licenseId": "HaskellReport",
             "seeAlso": [
@@ -3494,7 +3727,7 @@
             "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
-            "referenceNumber": 586,
+            "referenceNumber": 609,
             "name": "Hippocratic License 2.1",
             "licenseId": "Hippocratic-2.1",
             "seeAlso": [
@@ -3507,7 +3740,7 @@
             "reference": "https://spdx.org/licenses/IBM-pibs.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
-            "referenceNumber": 583,
+            "referenceNumber": 417,
             "name": "IBM PowerPC Initialization and Boot Software",
             "licenseId": "IBM-pibs",
             "seeAlso": [
@@ -3519,19 +3752,19 @@
             "reference": "https://spdx.org/licenses/ICU.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ICU.json",
-            "referenceNumber": 192,
+            "referenceNumber": 153,
             "name": "ICU License",
             "licenseId": "ICU",
             "seeAlso": [
                 "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
             ],
-            "isOsiApproved": false
+            "isOsiApproved": true
         },
         {
             "reference": "https://spdx.org/licenses/IEC-Code-Components-EULA.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/IEC-Code-Components-EULA.json",
-            "referenceNumber": 322,
+            "referenceNumber": 481,
             "name": "IEC    Code Components End-user licence agreement",
             "licenseId": "IEC-Code-Components-EULA",
             "seeAlso": [
@@ -3545,7 +3778,7 @@
             "reference": "https://spdx.org/licenses/IJG.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/IJG.json",
-            "referenceNumber": 147,
+            "referenceNumber": 90,
             "name": "Independent JPEG Group License",
             "licenseId": "IJG",
             "seeAlso": [
@@ -3558,7 +3791,7 @@
             "reference": "https://spdx.org/licenses/IJG-short.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/IJG-short.json",
-            "referenceNumber": 285,
+            "referenceNumber": 520,
             "name": "Independent JPEG Group License - short",
             "licenseId": "IJG-short",
             "seeAlso": [
@@ -3570,7 +3803,7 @@
             "reference": "https://spdx.org/licenses/IPA.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/IPA.json",
-            "referenceNumber": 351,
+            "referenceNumber": 411,
             "name": "IPA Font License",
             "licenseId": "IPA",
             "seeAlso": [
@@ -3583,7 +3816,7 @@
             "reference": "https://spdx.org/licenses/IPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
-            "referenceNumber": 406,
+            "referenceNumber": 508,
             "name": "IBM Public License v1.0",
             "licenseId": "IPL-1.0",
             "seeAlso": [
@@ -3596,7 +3829,7 @@
             "reference": "https://spdx.org/licenses/ISC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ISC.json",
-            "referenceNumber": 201,
+            "referenceNumber": 483,
             "name": "ISC License",
             "licenseId": "ISC",
             "seeAlso": [
@@ -3608,10 +3841,23 @@
             "isFsfLibre": true
         },
         {
+            "reference": "https://spdx.org/licenses/ISC-Veillard.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/ISC-Veillard.json",
+            "referenceNumber": 446,
+            "name": "ISC Veillard variant",
+            "licenseId": "ISC-Veillard",
+            "seeAlso": [
+                "https://raw.githubusercontent.com/GNOME/libxml2/4c2e7c651f6c2f0d1a74f350cbda95f7df3e7017/hash.c",
+                "https://github.com/GNOME/libxml2/blob/master/dict.c"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/ImageMagick.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
-            "referenceNumber": 5,
+            "referenceNumber": 557,
             "name": "ImageMagick License",
             "licenseId": "ImageMagick",
             "seeAlso": [
@@ -3623,7 +3869,7 @@
             "reference": "https://spdx.org/licenses/Imlib2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
-            "referenceNumber": 166,
+            "referenceNumber": 280,
             "name": "Imlib2 License",
             "licenseId": "Imlib2",
             "seeAlso": [
@@ -3637,7 +3883,7 @@
             "reference": "https://spdx.org/licenses/Info-ZIP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
-            "referenceNumber": 535,
+            "referenceNumber": 136,
             "name": "Info-ZIP License",
             "licenseId": "Info-ZIP",
             "seeAlso": [
@@ -3649,7 +3895,7 @@
             "reference": "https://spdx.org/licenses/Inner-Net-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Inner-Net-2.0.json",
-            "referenceNumber": 401,
+            "referenceNumber": 277,
             "name": "Inner Net License v2.0",
             "licenseId": "Inner-Net-2.0",
             "seeAlso": [
@@ -3662,7 +3908,7 @@
             "reference": "https://spdx.org/licenses/Intel.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Intel.json",
-            "referenceNumber": 432,
+            "referenceNumber": 187,
             "name": "Intel Open Source License",
             "licenseId": "Intel",
             "seeAlso": [
@@ -3675,7 +3921,7 @@
             "reference": "https://spdx.org/licenses/Intel-ACPI.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
-            "referenceNumber": 102,
+            "referenceNumber": 554,
             "name": "Intel ACPI Software License Agreement",
             "licenseId": "Intel-ACPI",
             "seeAlso": [
@@ -3687,7 +3933,7 @@
             "reference": "https://spdx.org/licenses/Interbase-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
-            "referenceNumber": 593,
+            "referenceNumber": 632,
             "name": "Interbase Public License v1.0",
             "licenseId": "Interbase-1.0",
             "seeAlso": [
@@ -3699,7 +3945,7 @@
             "reference": "https://spdx.org/licenses/JPL-image.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/JPL-image.json",
-            "referenceNumber": 582,
+            "referenceNumber": 379,
             "name": "JPL Image Use Policy",
             "licenseId": "JPL-image",
             "seeAlso": [
@@ -3711,7 +3957,7 @@
             "reference": "https://spdx.org/licenses/JPNIC.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
-            "referenceNumber": 26,
+            "referenceNumber": 103,
             "name": "Japan Network Information Center License",
             "licenseId": "JPNIC",
             "seeAlso": [
@@ -3723,7 +3969,7 @@
             "reference": "https://spdx.org/licenses/JSON.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/JSON.json",
-            "referenceNumber": 239,
+            "referenceNumber": 219,
             "name": "JSON License",
             "licenseId": "JSON",
             "seeAlso": [
@@ -3736,7 +3982,7 @@
             "reference": "https://spdx.org/licenses/Jam.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Jam.json",
-            "referenceNumber": 211,
+            "referenceNumber": 4,
             "name": "Jam License",
             "licenseId": "Jam",
             "seeAlso": [
@@ -3749,7 +3995,7 @@
             "reference": "https://spdx.org/licenses/JasPer-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
-            "referenceNumber": 417,
+            "referenceNumber": 593,
             "name": "JasPer License",
             "licenseId": "JasPer-2.0",
             "seeAlso": [
@@ -3761,7 +4007,7 @@
             "reference": "https://spdx.org/licenses/Kastrup.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Kastrup.json",
-            "referenceNumber": 486,
+            "referenceNumber": 406,
             "name": "Kastrup License",
             "licenseId": "Kastrup",
             "seeAlso": [
@@ -3773,7 +4019,7 @@
             "reference": "https://spdx.org/licenses/Kazlib.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Kazlib.json",
-            "referenceNumber": 105,
+            "referenceNumber": 257,
             "name": "Kazlib License",
             "licenseId": "Kazlib",
             "seeAlso": [
@@ -3785,7 +4031,7 @@
             "reference": "https://spdx.org/licenses/Knuth-CTAN.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Knuth-CTAN.json",
-            "referenceNumber": 132,
+            "referenceNumber": 514,
             "name": "Knuth CTAN License",
             "licenseId": "Knuth-CTAN",
             "seeAlso": [
@@ -3797,7 +4043,7 @@
             "reference": "https://spdx.org/licenses/LAL-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
-            "referenceNumber": 397,
+            "referenceNumber": 621,
             "name": "Licence Art Libre 1.2",
             "licenseId": "LAL-1.2",
             "seeAlso": [
@@ -3809,7 +4055,7 @@
             "reference": "https://spdx.org/licenses/LAL-1.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
-            "referenceNumber": 531,
+            "referenceNumber": 182,
             "name": "Licence Art Libre 1.3",
             "licenseId": "LAL-1.3",
             "seeAlso": [
@@ -3821,7 +4067,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
-            "referenceNumber": 59,
+            "referenceNumber": 452,
             "name": "GNU Library General Public License v2 only",
             "licenseId": "LGPL-2.0",
             "seeAlso": [
@@ -3833,7 +4079,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
-            "referenceNumber": 576,
+            "referenceNumber": 342,
             "name": "GNU Library General Public License v2 or later",
             "licenseId": "LGPL-2.0+",
             "seeAlso": [
@@ -3845,7 +4091,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-only.json",
-            "referenceNumber": 385,
+            "referenceNumber": 563,
             "name": "GNU Library General Public License v2 only",
             "licenseId": "LGPL-2.0-only",
             "seeAlso": [
@@ -3857,7 +4103,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
-            "referenceNumber": 101,
+            "referenceNumber": 575,
             "name": "GNU Library General Public License v2 or later",
             "licenseId": "LGPL-2.0-or-later",
             "seeAlso": [
@@ -3869,7 +4115,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.1.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
-            "referenceNumber": 363,
+            "referenceNumber": 394,
             "name": "GNU Lesser General Public License v2.1 only",
             "licenseId": "LGPL-2.1",
             "seeAlso": [
@@ -3883,7 +4129,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
-            "referenceNumber": 245,
+            "referenceNumber": 12,
             "name": "GNU Lesser General Public License v2.1 or later",
             "licenseId": "LGPL-2.1+",
             "seeAlso": [
@@ -3897,7 +4143,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
-            "referenceNumber": 182,
+            "referenceNumber": 180,
             "name": "GNU Lesser General Public License v2.1 only",
             "licenseId": "LGPL-2.1-only",
             "seeAlso": [
@@ -3911,7 +4157,7 @@
             "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
-            "referenceNumber": 484,
+            "referenceNumber": 422,
             "name": "GNU Lesser General Public License v2.1 or later",
             "licenseId": "LGPL-2.1-or-later",
             "seeAlso": [
@@ -3925,7 +4171,7 @@
             "reference": "https://spdx.org/licenses/LGPL-3.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
-            "referenceNumber": 362,
+            "referenceNumber": 636,
             "name": "GNU Lesser General Public License v3.0 only",
             "licenseId": "LGPL-3.0",
             "seeAlso": [
@@ -3940,7 +4186,7 @@
             "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
-            "referenceNumber": 573,
+            "referenceNumber": 255,
             "name": "GNU Lesser General Public License v3.0 or later",
             "licenseId": "LGPL-3.0+",
             "seeAlso": [
@@ -3955,7 +4201,7 @@
             "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
-            "referenceNumber": 248,
+            "referenceNumber": 83,
             "name": "GNU Lesser General Public License v3.0 only",
             "licenseId": "LGPL-3.0-only",
             "seeAlso": [
@@ -3970,7 +4216,7 @@
             "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
-            "referenceNumber": 418,
+            "referenceNumber": 396,
             "name": "GNU Lesser General Public License v3.0 or later",
             "licenseId": "LGPL-3.0-or-later",
             "seeAlso": [
@@ -3985,7 +4231,7 @@
             "reference": "https://spdx.org/licenses/LGPLLR.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
-            "referenceNumber": 549,
+            "referenceNumber": 135,
             "name": "Lesser General Public License For Linguistic Resources",
             "licenseId": "LGPLLR",
             "seeAlso": [
@@ -3997,7 +4243,7 @@
             "reference": "https://spdx.org/licenses/LOOP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LOOP.json",
-            "referenceNumber": 379,
+            "referenceNumber": 263,
             "name": "Common Lisp LOOP License",
             "licenseId": "LOOP",
             "seeAlso": [
@@ -4011,10 +4257,23 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/LPD-document.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/LPD-document.json",
+            "referenceNumber": 271,
+            "name": "LPD Documentation License",
+            "licenseId": "LPD-document",
+            "seeAlso": [
+                "https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md",
+                "https://www.ietf.org/rfc/rfc1952.txt"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/LPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
-            "referenceNumber": 544,
+            "referenceNumber": 468,
             "name": "Lucent Public License Version 1.0",
             "licenseId": "LPL-1.0",
             "seeAlso": [
@@ -4026,7 +4285,7 @@
             "reference": "https://spdx.org/licenses/LPL-1.02.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
-            "referenceNumber": 407,
+            "referenceNumber": 436,
             "name": "Lucent Public License v1.02",
             "licenseId": "LPL-1.02",
             "seeAlso": [
@@ -4040,7 +4299,7 @@
             "reference": "https://spdx.org/licenses/LPPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
-            "referenceNumber": 58,
+            "referenceNumber": 112,
             "name": "LaTeX Project Public License v1.0",
             "licenseId": "LPPL-1.0",
             "seeAlso": [
@@ -4052,7 +4311,7 @@
             "reference": "https://spdx.org/licenses/LPPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
-            "referenceNumber": 360,
+            "referenceNumber": 386,
             "name": "LaTeX Project Public License v1.1",
             "licenseId": "LPPL-1.1",
             "seeAlso": [
@@ -4064,7 +4323,7 @@
             "reference": "https://spdx.org/licenses/LPPL-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
-            "referenceNumber": 156,
+            "referenceNumber": 517,
             "name": "LaTeX Project Public License v1.2",
             "licenseId": "LPPL-1.2",
             "seeAlso": [
@@ -4077,7 +4336,7 @@
             "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
-            "referenceNumber": 553,
+            "referenceNumber": 478,
             "name": "LaTeX Project Public License v1.3a",
             "licenseId": "LPPL-1.3a",
             "seeAlso": [
@@ -4090,7 +4349,7 @@
             "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
-            "referenceNumber": 514,
+            "referenceNumber": 85,
             "name": "LaTeX Project Public License v1.3c",
             "licenseId": "LPPL-1.3c",
             "seeAlso": [
@@ -4103,7 +4362,7 @@
             "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
-            "referenceNumber": 89,
+            "referenceNumber": 378,
             "name": "LZMA SDK License (versions 9.11 to 9.20)",
             "licenseId": "LZMA-SDK-9.11-to-9.20",
             "seeAlso": [
@@ -4116,7 +4375,7 @@
             "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
-            "referenceNumber": 63,
+            "referenceNumber": 253,
             "name": "LZMA SDK License (versions 9.22 and beyond)",
             "licenseId": "LZMA-SDK-9.22",
             "seeAlso": [
@@ -4129,7 +4388,7 @@
             "reference": "https://spdx.org/licenses/Latex2e.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
-            "referenceNumber": 511,
+            "referenceNumber": 254,
             "name": "Latex2e License",
             "licenseId": "Latex2e",
             "seeAlso": [
@@ -4141,7 +4400,7 @@
             "reference": "https://spdx.org/licenses/Latex2e-translated-notice.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Latex2e-translated-notice.json",
-            "referenceNumber": 567,
+            "referenceNumber": 435,
             "name": "Latex2e with translated notice permission",
             "licenseId": "Latex2e-translated-notice",
             "seeAlso": [
@@ -4153,7 +4412,7 @@
             "reference": "https://spdx.org/licenses/Leptonica.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
-            "referenceNumber": 506,
+            "referenceNumber": 294,
             "name": "Leptonica License",
             "licenseId": "Leptonica",
             "seeAlso": [
@@ -4165,7 +4424,7 @@
             "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
-            "referenceNumber": 384,
+            "referenceNumber": 534,
             "name": "Licence Libre du Qu\u00e9bec \u2013 Permissive version 1.1",
             "licenseId": "LiLiQ-P-1.1",
             "seeAlso": [
@@ -4178,7 +4437,7 @@
             "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
-            "referenceNumber": 375,
+            "referenceNumber": 65,
             "name": "Licence Libre du Qu\u00e9bec \u2013 R\u00e9ciprocit\u00e9 version 1.1",
             "licenseId": "LiLiQ-R-1.1",
             "seeAlso": [
@@ -4191,7 +4450,7 @@
             "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-            "referenceNumber": 98,
+            "referenceNumber": 500,
             "name": "Licence Libre du Qu\u00e9bec \u2013 R\u00e9ciprocit\u00e9 forte version 1.1",
             "licenseId": "LiLiQ-Rplus-1.1",
             "seeAlso": [
@@ -4204,7 +4463,7 @@
             "reference": "https://spdx.org/licenses/Libpng.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Libpng.json",
-            "referenceNumber": 419,
+            "referenceNumber": 140,
             "name": "libpng License",
             "licenseId": "Libpng",
             "seeAlso": [
@@ -4216,7 +4475,7 @@
             "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
-            "referenceNumber": 378,
+            "referenceNumber": 487,
             "name": "Linux Kernel Variant of OpenIB.org license",
             "licenseId": "Linux-OpenIB",
             "seeAlso": [
@@ -4228,7 +4487,7 @@
             "reference": "https://spdx.org/licenses/Linux-man-pages-1-para.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-1-para.json",
-            "referenceNumber": 189,
+            "referenceNumber": 188,
             "name": "Linux man-pages - 1 paragraph",
             "licenseId": "Linux-man-pages-1-para",
             "seeAlso": [
@@ -4240,7 +4499,7 @@
             "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
-            "referenceNumber": 199,
+            "referenceNumber": 496,
             "name": "Linux man-pages Copyleft",
             "licenseId": "Linux-man-pages-copyleft",
             "seeAlso": [
@@ -4252,7 +4511,7 @@
             "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.json",
-            "referenceNumber": 135,
+            "referenceNumber": 460,
             "name": "Linux man-pages Copyleft - 2 paragraphs",
             "licenseId": "Linux-man-pages-copyleft-2-para",
             "seeAlso": [
@@ -4265,7 +4524,7 @@
             "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.json",
-            "referenceNumber": 420,
+            "referenceNumber": 105,
             "name": "Linux man-pages Copyleft Variant",
             "licenseId": "Linux-man-pages-copyleft-var",
             "seeAlso": [
@@ -4277,7 +4536,7 @@
             "reference": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.json",
-            "referenceNumber": 214,
+            "referenceNumber": 62,
             "name": "Lucida Bitmap Fonts License",
             "licenseId": "Lucida-Bitmap-Fonts",
             "seeAlso": [
@@ -4289,11 +4548,11 @@
             "reference": "https://spdx.org/licenses/MIT.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT.json",
-            "referenceNumber": 246,
+            "referenceNumber": 124,
             "name": "MIT License",
             "licenseId": "MIT",
             "seeAlso": [
-                "https://opensource.org/licenses/MIT"
+                "https://opensource.org/license/mit/"
             ],
             "isOsiApproved": true,
             "isFsfLibre": true
@@ -4302,7 +4561,7 @@
             "reference": "https://spdx.org/licenses/MIT-0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
-            "referenceNumber": 185,
+            "referenceNumber": 238,
             "name": "MIT No Attribution",
             "licenseId": "MIT-0",
             "seeAlso": [
@@ -4316,7 +4575,7 @@
             "reference": "https://spdx.org/licenses/MIT-CMU.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
-            "referenceNumber": 346,
+            "referenceNumber": 415,
             "name": "CMU License",
             "licenseId": "MIT-CMU",
             "seeAlso": [
@@ -4329,7 +4588,7 @@
             "reference": "https://spdx.org/licenses/MIT-Festival.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-Festival.json",
-            "referenceNumber": 494,
+            "referenceNumber": 595,
             "name": "MIT Festival Variant",
             "licenseId": "MIT-Festival",
             "seeAlso": [
@@ -4342,7 +4601,7 @@
             "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
-            "referenceNumber": 467,
+            "referenceNumber": 44,
             "name": "MIT License Modern Variant",
             "licenseId": "MIT-Modern-Variant",
             "seeAlso": [
@@ -4356,7 +4615,7 @@
             "reference": "https://spdx.org/licenses/MIT-Wu.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-Wu.json",
-            "referenceNumber": 229,
+            "referenceNumber": 608,
             "name": "MIT Tom Wu Variant",
             "licenseId": "MIT-Wu",
             "seeAlso": [
@@ -4368,7 +4627,7 @@
             "reference": "https://spdx.org/licenses/MIT-advertising.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
-            "referenceNumber": 78,
+            "referenceNumber": 77,
             "name": "Enlightenment License (e16)",
             "licenseId": "MIT-advertising",
             "seeAlso": [
@@ -4380,7 +4639,7 @@
             "reference": "https://spdx.org/licenses/MIT-enna.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
-            "referenceNumber": 10,
+            "referenceNumber": 129,
             "name": "enna License",
             "licenseId": "MIT-enna",
             "seeAlso": [
@@ -4392,7 +4651,7 @@
             "reference": "https://spdx.org/licenses/MIT-feh.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
-            "referenceNumber": 274,
+            "referenceNumber": 37,
             "name": "feh License",
             "licenseId": "MIT-feh",
             "seeAlso": [
@@ -4404,7 +4663,7 @@
             "reference": "https://spdx.org/licenses/MIT-open-group.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
-            "referenceNumber": 492,
+            "referenceNumber": 543,
             "name": "MIT Open Group variant",
             "licenseId": "MIT-open-group",
             "seeAlso": [
@@ -4419,7 +4678,7 @@
             "reference": "https://spdx.org/licenses/MIT-testregex.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MIT-testregex.json",
-            "referenceNumber": 133,
+            "referenceNumber": 250,
             "name": "MIT testregex Variant",
             "licenseId": "MIT-testregex",
             "seeAlso": [
@@ -4431,7 +4690,7 @@
             "reference": "https://spdx.org/licenses/MITNFA.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
-            "referenceNumber": 164,
+            "referenceNumber": 526,
             "name": "MIT +no-false-attribs license",
             "licenseId": "MITNFA",
             "seeAlso": [
@@ -4443,7 +4702,7 @@
             "reference": "https://spdx.org/licenses/MMIXware.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MMIXware.json",
-            "referenceNumber": 326,
+            "referenceNumber": 252,
             "name": "MMIXware License",
             "licenseId": "MMIXware",
             "seeAlso": [
@@ -4455,7 +4714,7 @@
             "reference": "https://spdx.org/licenses/MPEG-SSG.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MPEG-SSG.json",
-            "referenceNumber": 56,
+            "referenceNumber": 202,
             "name": "MPEG Software Simulation",
             "licenseId": "MPEG-SSG",
             "seeAlso": [
@@ -4467,7 +4726,7 @@
             "reference": "https://spdx.org/licenses/MPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
-            "referenceNumber": 17,
+            "referenceNumber": 499,
             "name": "Mozilla Public License 1.0",
             "licenseId": "MPL-1.0",
             "seeAlso": [
@@ -4480,7 +4739,7 @@
             "reference": "https://spdx.org/licenses/MPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
-            "referenceNumber": 256,
+            "referenceNumber": 183,
             "name": "Mozilla Public License 1.1",
             "licenseId": "MPL-1.1",
             "seeAlso": [
@@ -4494,7 +4753,7 @@
             "reference": "https://spdx.org/licenses/MPL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
-            "referenceNumber": 487,
+            "referenceNumber": 573,
             "name": "Mozilla Public License 2.0",
             "licenseId": "MPL-2.0",
             "seeAlso": [
@@ -4508,7 +4767,7 @@
             "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-            "referenceNumber": 50,
+            "referenceNumber": 397,
             "name": "Mozilla Public License 2.0 (no copyleft exception)",
             "licenseId": "MPL-2.0-no-copyleft-exception",
             "seeAlso": [
@@ -4521,7 +4780,7 @@
             "reference": "https://spdx.org/licenses/MS-LPL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
-            "referenceNumber": 236,
+            "referenceNumber": 199,
             "name": "Microsoft Limited Public License",
             "licenseId": "MS-LPL",
             "seeAlso": [
@@ -4535,7 +4794,7 @@
             "reference": "https://spdx.org/licenses/MS-PL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
-            "referenceNumber": 503,
+            "referenceNumber": 485,
             "name": "Microsoft Public License",
             "licenseId": "MS-PL",
             "seeAlso": [
@@ -4549,7 +4808,7 @@
             "reference": "https://spdx.org/licenses/MS-RL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
-            "referenceNumber": 395,
+            "referenceNumber": 284,
             "name": "Microsoft Reciprocal License",
             "licenseId": "MS-RL",
             "seeAlso": [
@@ -4563,7 +4822,7 @@
             "reference": "https://spdx.org/licenses/MTLL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MTLL.json",
-            "referenceNumber": 392,
+            "referenceNumber": 387,
             "name": "Matrix Template Library License",
             "licenseId": "MTLL",
             "seeAlso": [
@@ -4572,10 +4831,34 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/Mackerras-3-Clause.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause.json",
+            "referenceNumber": 42,
+            "name": "Mackerras 3-Clause License",
+            "licenseId": "Mackerras-3-Clause",
+            "seeAlso": [
+                "https://github.com/ppp-project/ppp/blob/master/pppd/chap_ms.c#L6-L28"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.json",
+            "referenceNumber": 605,
+            "name": "Mackerras 3-Clause - acknowledgment variant",
+            "licenseId": "Mackerras-3-Clause-acknowledgment",
+            "seeAlso": [
+                "https://github.com/ppp-project/ppp/blob/master/pppd/auth.c#L6-L28"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/MakeIndex.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
-            "referenceNumber": 142,
+            "referenceNumber": 22,
             "name": "MakeIndex License",
             "licenseId": "MakeIndex",
             "seeAlso": [
@@ -4587,7 +4870,7 @@
             "reference": "https://spdx.org/licenses/Martin-Birgmeier.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Martin-Birgmeier.json",
-            "referenceNumber": 482,
+            "referenceNumber": 382,
             "name": "Martin Birgmeier License",
             "licenseId": "Martin-Birgmeier",
             "seeAlso": [
@@ -4599,7 +4882,7 @@
             "reference": "https://spdx.org/licenses/McPhee-slideshow.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/McPhee-slideshow.json",
-            "referenceNumber": 9,
+            "referenceNumber": 288,
             "name": "McPhee Slideshow License",
             "licenseId": "McPhee-slideshow",
             "seeAlso": [
@@ -4611,7 +4894,7 @@
             "reference": "https://spdx.org/licenses/Minpack.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Minpack.json",
-            "referenceNumber": 364,
+            "referenceNumber": 179,
             "name": "Minpack License",
             "licenseId": "Minpack",
             "seeAlso": [
@@ -4624,7 +4907,7 @@
             "reference": "https://spdx.org/licenses/MirOS.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MirOS.json",
-            "referenceNumber": 308,
+            "referenceNumber": 23,
             "name": "The MirOS Licence",
             "licenseId": "MirOS",
             "seeAlso": [
@@ -4636,7 +4919,7 @@
             "reference": "https://spdx.org/licenses/Motosoto.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
-            "referenceNumber": 333,
+            "referenceNumber": 448,
             "name": "Motosoto License",
             "licenseId": "Motosoto",
             "seeAlso": [
@@ -4648,7 +4931,7 @@
             "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
-            "referenceNumber": 209,
+            "referenceNumber": 407,
             "name": "Mulan Permissive Software License, Version 1",
             "licenseId": "MulanPSL-1.0",
             "seeAlso": [
@@ -4661,11 +4944,11 @@
             "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
-            "referenceNumber": 304,
+            "referenceNumber": 439,
             "name": "Mulan Permissive Software License, Version 2",
             "licenseId": "MulanPSL-2.0",
             "seeAlso": [
-                "https://license.coscl.org.cn/MulanPSL2/"
+                "https://license.coscl.org.cn/MulanPSL2"
             ],
             "isOsiApproved": true
         },
@@ -4673,7 +4956,7 @@
             "reference": "https://spdx.org/licenses/Multics.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Multics.json",
-            "referenceNumber": 572,
+            "referenceNumber": 465,
             "name": "Multics License",
             "licenseId": "Multics",
             "seeAlso": [
@@ -4685,7 +4968,7 @@
             "reference": "https://spdx.org/licenses/Mup.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Mup.json",
-            "referenceNumber": 150,
+            "referenceNumber": 607,
             "name": "Mup License",
             "licenseId": "Mup",
             "seeAlso": [
@@ -4697,7 +4980,7 @@
             "reference": "https://spdx.org/licenses/NAIST-2003.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
-            "referenceNumber": 82,
+            "referenceNumber": 265,
             "name": "Nara Institute of Science and Technology License (2003)",
             "licenseId": "NAIST-2003",
             "seeAlso": [
@@ -4710,7 +4993,7 @@
             "reference": "https://spdx.org/licenses/NASA-1.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
-            "referenceNumber": 146,
+            "referenceNumber": 507,
             "name": "NASA Open Source Agreement 1.3",
             "licenseId": "NASA-1.3",
             "seeAlso": [
@@ -4724,7 +5007,7 @@
             "reference": "https://spdx.org/licenses/NBPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
-            "referenceNumber": 83,
+            "referenceNumber": 61,
             "name": "Net Boolean Public License v1",
             "licenseId": "NBPL-1.0",
             "seeAlso": [
@@ -4736,7 +5019,7 @@
             "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
-            "referenceNumber": 469,
+            "referenceNumber": 443,
             "name": "Non-Commercial Government Licence",
             "licenseId": "NCGL-UK-2.0",
             "seeAlso": [
@@ -4748,7 +5031,7 @@
             "reference": "https://spdx.org/licenses/NCSA.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NCSA.json",
-            "referenceNumber": 413,
+            "referenceNumber": 45,
             "name": "University of Illinois/NCSA Open Source License",
             "licenseId": "NCSA",
             "seeAlso": [
@@ -4762,7 +5045,7 @@
             "reference": "https://spdx.org/licenses/NGPL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NGPL.json",
-            "referenceNumber": 411,
+            "referenceNumber": 248,
             "name": "Nethack General Public License",
             "licenseId": "NGPL",
             "seeAlso": [
@@ -4774,7 +5057,7 @@
             "reference": "https://spdx.org/licenses/NICTA-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
-            "referenceNumber": 95,
+            "referenceNumber": 48,
             "name": "NICTA Public Software License, Version 1.0",
             "licenseId": "NICTA-1.0",
             "seeAlso": [
@@ -4786,7 +5069,7 @@
             "reference": "https://spdx.org/licenses/NIST-PD.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
-            "referenceNumber": 537,
+            "referenceNumber": 209,
             "name": "NIST Public Domain Notice",
             "licenseId": "NIST-PD",
             "seeAlso": [
@@ -4799,7 +5082,7 @@
             "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
-            "referenceNumber": 424,
+            "referenceNumber": 49,
             "name": "NIST Public Domain Notice with license fallback",
             "licenseId": "NIST-PD-fallback",
             "seeAlso": [
@@ -4812,7 +5095,7 @@
             "reference": "https://spdx.org/licenses/NIST-Software.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NIST-Software.json",
-            "referenceNumber": 547,
+            "referenceNumber": 94,
             "name": "NIST Software License",
             "licenseId": "NIST-Software",
             "seeAlso": [
@@ -4824,7 +5107,7 @@
             "reference": "https://spdx.org/licenses/NLOD-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
-            "referenceNumber": 409,
+            "referenceNumber": 217,
             "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
             "licenseId": "NLOD-1.0",
             "seeAlso": [
@@ -4836,7 +5119,7 @@
             "reference": "https://spdx.org/licenses/NLOD-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
-            "referenceNumber": 464,
+            "referenceNumber": 373,
             "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
             "licenseId": "NLOD-2.0",
             "seeAlso": [
@@ -4848,7 +5131,7 @@
             "reference": "https://spdx.org/licenses/NLPL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NLPL.json",
-            "referenceNumber": 21,
+            "referenceNumber": 66,
             "name": "No Limit Public License",
             "licenseId": "NLPL",
             "seeAlso": [
@@ -4873,7 +5156,7 @@
             "reference": "https://spdx.org/licenses/NPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
-            "referenceNumber": 318,
+            "referenceNumber": 210,
             "name": "Netscape Public License v1.0",
             "licenseId": "NPL-1.0",
             "seeAlso": [
@@ -4886,7 +5169,7 @@
             "reference": "https://spdx.org/licenses/NPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
-            "referenceNumber": 459,
+            "referenceNumber": 337,
             "name": "Netscape Public License v1.1",
             "licenseId": "NPL-1.1",
             "seeAlso": [
@@ -4899,7 +5182,7 @@
             "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
-            "referenceNumber": 597,
+            "referenceNumber": 635,
             "name": "Non-Profit Open Software License 3.0",
             "licenseId": "NPOSL-3.0",
             "seeAlso": [
@@ -4911,7 +5194,7 @@
             "reference": "https://spdx.org/licenses/NRL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NRL.json",
-            "referenceNumber": 299,
+            "referenceNumber": 369,
             "name": "NRL License",
             "licenseId": "NRL",
             "seeAlso": [
@@ -4923,7 +5206,7 @@
             "reference": "https://spdx.org/licenses/NTP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NTP.json",
-            "referenceNumber": 210,
+            "referenceNumber": 470,
             "name": "NTP License",
             "licenseId": "NTP",
             "seeAlso": [
@@ -4935,7 +5218,7 @@
             "reference": "https://spdx.org/licenses/NTP-0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
-            "referenceNumber": 470,
+            "referenceNumber": 186,
             "name": "NTP No Attribution",
             "licenseId": "NTP-0",
             "seeAlso": [
@@ -4947,7 +5230,7 @@
             "reference": "https://spdx.org/licenses/Naumen.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Naumen.json",
-            "referenceNumber": 225,
+            "referenceNumber": 221,
             "name": "Naumen Public License",
             "licenseId": "Naumen",
             "seeAlso": [
@@ -4959,7 +5242,7 @@
             "reference": "https://spdx.org/licenses/Net-SNMP.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
-            "referenceNumber": 428,
+            "referenceNumber": 71,
             "name": "Net-SNMP License",
             "licenseId": "Net-SNMP",
             "seeAlso": [
@@ -4971,7 +5254,7 @@
             "reference": "https://spdx.org/licenses/NetCDF.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
-            "referenceNumber": 558,
+            "referenceNumber": 119,
             "name": "NetCDF license",
             "licenseId": "NetCDF",
             "seeAlso": [
@@ -4983,7 +5266,7 @@
             "reference": "https://spdx.org/licenses/Newsletr.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
-            "referenceNumber": 305,
+            "referenceNumber": 616,
             "name": "Newsletr License",
             "licenseId": "Newsletr",
             "seeAlso": [
@@ -4995,7 +5278,7 @@
             "reference": "https://spdx.org/licenses/Nokia.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Nokia.json",
-            "referenceNumber": 276,
+            "referenceNumber": 128,
             "name": "Nokia Open Source License",
             "licenseId": "Nokia",
             "seeAlso": [
@@ -5008,7 +5291,7 @@
             "reference": "https://spdx.org/licenses/Noweb.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Noweb.json",
-            "referenceNumber": 149,
+            "referenceNumber": 476,
             "name": "Noweb License",
             "licenseId": "Noweb",
             "seeAlso": [
@@ -5020,7 +5303,7 @@
             "reference": "https://spdx.org/licenses/Nunit.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/Nunit.json",
-            "referenceNumber": 303,
+            "referenceNumber": 471,
             "name": "Nunit License",
             "licenseId": "Nunit",
             "seeAlso": [
@@ -5033,7 +5316,7 @@
             "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
-            "referenceNumber": 3,
+            "referenceNumber": 118,
             "name": "Open Use of Data Agreement v1.0",
             "licenseId": "O-UDA-1.0",
             "seeAlso": [
@@ -5046,7 +5329,7 @@
             "reference": "https://spdx.org/licenses/OCCT-PL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
-            "referenceNumber": 247,
+            "referenceNumber": 521,
             "name": "Open CASCADE Technology Public License",
             "licenseId": "OCCT-PL",
             "seeAlso": [
@@ -5058,7 +5341,7 @@
             "reference": "https://spdx.org/licenses/OCLC-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
-            "referenceNumber": 235,
+            "referenceNumber": 566,
             "name": "OCLC Research Public License 2.0",
             "licenseId": "OCLC-2.0",
             "seeAlso": [
@@ -5071,7 +5354,7 @@
             "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
-            "referenceNumber": 152,
+            "referenceNumber": 141,
             "name": "Open Data Commons Attribution License v1.0",
             "licenseId": "ODC-By-1.0",
             "seeAlso": [
@@ -5083,7 +5366,7 @@
             "reference": "https://spdx.org/licenses/ODbL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
-            "referenceNumber": 348,
+            "referenceNumber": 589,
             "name": "Open Data Commons Open Database License v1.0",
             "licenseId": "ODbL-1.0",
             "seeAlso": [
@@ -5097,7 +5380,7 @@
             "reference": "https://spdx.org/licenses/OFFIS.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OFFIS.json",
-            "referenceNumber": 510,
+            "referenceNumber": 603,
             "name": "OFFIS License",
             "licenseId": "OFFIS",
             "seeAlso": [
@@ -5109,7 +5392,7 @@
             "reference": "https://spdx.org/licenses/OFL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
-            "referenceNumber": 159,
+            "referenceNumber": 91,
             "name": "SIL Open Font License 1.0",
             "licenseId": "OFL-1.0",
             "seeAlso": [
@@ -5122,7 +5405,7 @@
             "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
-            "referenceNumber": 14,
+            "referenceNumber": 568,
             "name": "SIL Open Font License 1.0 with Reserved Font Name",
             "licenseId": "OFL-1.0-RFN",
             "seeAlso": [
@@ -5134,7 +5417,7 @@
             "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
-            "referenceNumber": 74,
+            "referenceNumber": 149,
             "name": "SIL Open Font License 1.0 with no Reserved Font Name",
             "licenseId": "OFL-1.0-no-RFN",
             "seeAlso": [
@@ -5146,7 +5429,7 @@
             "reference": "https://spdx.org/licenses/OFL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
-            "referenceNumber": 505,
+            "referenceNumber": 163,
             "name": "SIL Open Font License 1.1",
             "licenseId": "OFL-1.1",
             "seeAlso": [
@@ -5160,7 +5443,7 @@
             "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
-            "referenceNumber": 127,
+            "referenceNumber": 80,
             "name": "SIL Open Font License 1.1 with Reserved Font Name",
             "licenseId": "OFL-1.1-RFN",
             "seeAlso": [
@@ -5173,7 +5456,7 @@
             "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
-            "referenceNumber": 200,
+            "referenceNumber": 270,
             "name": "SIL Open Font License 1.1 with no Reserved Font Name",
             "licenseId": "OFL-1.1-no-RFN",
             "seeAlso": [
@@ -5186,7 +5469,7 @@
             "reference": "https://spdx.org/licenses/OGC-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
-            "referenceNumber": 389,
+            "referenceNumber": 86,
             "name": "OGC Software License, Version 1.0",
             "licenseId": "OGC-1.0",
             "seeAlso": [
@@ -5198,7 +5481,7 @@
             "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
-            "referenceNumber": 257,
+            "referenceNumber": 347,
             "name": "Taiwan Open Government Data License, version 1.0",
             "licenseId": "OGDL-Taiwan-1.0",
             "seeAlso": [
@@ -5210,7 +5493,7 @@
             "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
-            "referenceNumber": 301,
+            "referenceNumber": 506,
             "name": "Open Government Licence - Canada",
             "licenseId": "OGL-Canada-2.0",
             "seeAlso": [
@@ -5222,7 +5505,7 @@
             "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
-            "referenceNumber": 41,
+            "referenceNumber": 245,
             "name": "Open Government Licence v1.0",
             "licenseId": "OGL-UK-1.0",
             "seeAlso": [
@@ -5234,7 +5517,7 @@
             "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
-            "referenceNumber": 448,
+            "referenceNumber": 399,
             "name": "Open Government Licence v2.0",
             "licenseId": "OGL-UK-2.0",
             "seeAlso": [
@@ -5246,7 +5529,7 @@
             "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
-            "referenceNumber": 361,
+            "referenceNumber": 142,
             "name": "Open Government Licence v3.0",
             "licenseId": "OGL-UK-3.0",
             "seeAlso": [
@@ -5258,7 +5541,7 @@
             "reference": "https://spdx.org/licenses/OGTSL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
-            "referenceNumber": 435,
+            "referenceNumber": 214,
             "name": "Open Group Test Suite License",
             "licenseId": "OGTSL",
             "seeAlso": [
@@ -5271,7 +5554,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
-            "referenceNumber": 94,
+            "referenceNumber": 565,
             "name": "Open LDAP Public License v1.1",
             "licenseId": "OLDAP-1.1",
             "seeAlso": [
@@ -5283,7 +5566,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
-            "referenceNumber": 400,
+            "referenceNumber": 321,
             "name": "Open LDAP Public License v1.2",
             "licenseId": "OLDAP-1.2",
             "seeAlso": [
@@ -5295,7 +5578,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
-            "referenceNumber": 198,
+            "referenceNumber": 312,
             "name": "Open LDAP Public License v1.3",
             "licenseId": "OLDAP-1.3",
             "seeAlso": [
@@ -5307,7 +5590,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
-            "referenceNumber": 325,
+            "referenceNumber": 120,
             "name": "Open LDAP Public License v1.4",
             "licenseId": "OLDAP-1.4",
             "seeAlso": [
@@ -5319,7 +5602,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
-            "referenceNumber": 219,
+            "referenceNumber": 450,
             "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
             "licenseId": "OLDAP-2.0",
             "seeAlso": [
@@ -5331,7 +5614,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
-            "referenceNumber": 136,
+            "referenceNumber": 59,
             "name": "Open LDAP Public License v2.0.1",
             "licenseId": "OLDAP-2.0.1",
             "seeAlso": [
@@ -5343,7 +5626,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
-            "referenceNumber": 264,
+            "referenceNumber": 458,
             "name": "Open LDAP Public License v2.1",
             "licenseId": "OLDAP-2.1",
             "seeAlso": [
@@ -5355,7 +5638,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
-            "referenceNumber": 109,
+            "referenceNumber": 175,
             "name": "Open LDAP Public License v2.2",
             "licenseId": "OLDAP-2.2",
             "seeAlso": [
@@ -5367,7 +5650,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
-            "referenceNumber": 398,
+            "referenceNumber": 32,
             "name": "Open LDAP Public License v2.2.1",
             "licenseId": "OLDAP-2.2.1",
             "seeAlso": [
@@ -5379,7 +5662,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
-            "referenceNumber": 421,
+            "referenceNumber": 293,
             "name": "Open LDAP Public License 2.2.2",
             "licenseId": "OLDAP-2.2.2",
             "seeAlso": [
@@ -5391,7 +5674,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
-            "referenceNumber": 592,
+            "referenceNumber": 405,
             "name": "Open LDAP Public License v2.3",
             "licenseId": "OLDAP-2.3",
             "seeAlso": [
@@ -5404,7 +5687,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
-            "referenceNumber": 382,
+            "referenceNumber": 619,
             "name": "Open LDAP Public License v2.4",
             "licenseId": "OLDAP-2.4",
             "seeAlso": [
@@ -5416,7 +5699,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
-            "referenceNumber": 594,
+            "referenceNumber": 426,
             "name": "Open LDAP Public License v2.5",
             "licenseId": "OLDAP-2.5",
             "seeAlso": [
@@ -5428,7 +5711,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
-            "referenceNumber": 90,
+            "referenceNumber": 9,
             "name": "Open LDAP Public License v2.6",
             "licenseId": "OLDAP-2.6",
             "seeAlso": [
@@ -5440,7 +5723,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
-            "referenceNumber": 258,
+            "referenceNumber": 178,
             "name": "Open LDAP Public License v2.7",
             "licenseId": "OLDAP-2.7",
             "seeAlso": [
@@ -5453,7 +5736,7 @@
             "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
-            "referenceNumber": 190,
+            "referenceNumber": 132,
             "name": "Open LDAP Public License v2.8",
             "licenseId": "OLDAP-2.8",
             "seeAlso": [
@@ -5465,7 +5748,7 @@
             "reference": "https://spdx.org/licenses/OLFL-1.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OLFL-1.3.json",
-            "referenceNumber": 545,
+            "referenceNumber": 556,
             "name": "Open Logistics Foundation License Version 1.3",
             "licenseId": "OLFL-1.3",
             "seeAlso": [
@@ -5478,7 +5761,7 @@
             "reference": "https://spdx.org/licenses/OML.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OML.json",
-            "referenceNumber": 191,
+            "referenceNumber": 325,
             "name": "Open Market License",
             "licenseId": "OML",
             "seeAlso": [
@@ -5490,7 +5773,7 @@
             "reference": "https://spdx.org/licenses/OPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
-            "referenceNumber": 477,
+            "referenceNumber": 116,
             "name": "Open Public License v1.0",
             "licenseId": "OPL-1.0",
             "seeAlso": [
@@ -5504,7 +5787,7 @@
             "reference": "https://spdx.org/licenses/OPL-UK-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OPL-UK-3.0.json",
-            "referenceNumber": 119,
+            "referenceNumber": 276,
             "name": "United    Kingdom Open Parliament Licence v3.0",
             "licenseId": "OPL-UK-3.0",
             "seeAlso": [
@@ -5516,7 +5799,7 @@
             "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
-            "referenceNumber": 579,
+            "referenceNumber": 479,
             "name": "Open Publication License v1.0",
             "licenseId": "OPUBL-1.0",
             "seeAlso": [
@@ -5530,7 +5813,7 @@
             "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
-            "referenceNumber": 115,
+            "referenceNumber": 19,
             "name": "OSET Public License version 2.1",
             "licenseId": "OSET-PL-2.1",
             "seeAlso": [
@@ -5543,7 +5826,7 @@
             "reference": "https://spdx.org/licenses/OSL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
-            "referenceNumber": 453,
+            "referenceNumber": 511,
             "name": "Open Software License 1.0",
             "licenseId": "OSL-1.0",
             "seeAlso": [
@@ -5556,7 +5839,7 @@
             "reference": "https://spdx.org/licenses/OSL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
-            "referenceNumber": 279,
+            "referenceNumber": 327,
             "name": "Open Software License 1.1",
             "licenseId": "OSL-1.1",
             "seeAlso": [
@@ -5569,7 +5852,7 @@
             "reference": "https://spdx.org/licenses/OSL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
-            "referenceNumber": 86,
+            "referenceNumber": 579,
             "name": "Open Software License 2.0",
             "licenseId": "OSL-2.0",
             "seeAlso": [
@@ -5582,7 +5865,7 @@
             "reference": "https://spdx.org/licenses/OSL-2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
-            "referenceNumber": 11,
+            "referenceNumber": 480,
             "name": "Open Software License 2.1",
             "licenseId": "OSL-2.1",
             "seeAlso": [
@@ -5596,7 +5879,7 @@
             "reference": "https://spdx.org/licenses/OSL-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
-            "referenceNumber": 134,
+            "referenceNumber": 72,
             "name": "Open Software License 3.0",
             "licenseId": "OSL-3.0",
             "seeAlso": [
@@ -5610,7 +5893,7 @@
             "reference": "https://spdx.org/licenses/OpenPBS-2.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OpenPBS-2.3.json",
-            "referenceNumber": 327,
+            "referenceNumber": 490,
             "name": "OpenPBS v2.3 Software License",
             "licenseId": "OpenPBS-2.3",
             "seeAlso": [
@@ -5623,7 +5906,7 @@
             "reference": "https://spdx.org/licenses/OpenSSL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
-            "referenceNumber": 48,
+            "referenceNumber": 564,
             "name": "OpenSSL License",
             "licenseId": "OpenSSL",
             "seeAlso": [
@@ -5633,10 +5916,37 @@
             "isFsfLibre": true
         },
         {
+            "reference": "https://spdx.org/licenses/OpenSSL-standalone.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/OpenSSL-standalone.json",
+            "referenceNumber": 597,
+            "name": "OpenSSL License - standalone",
+            "licenseId": "OpenSSL-standalone",
+            "seeAlso": [
+                "https://library.netapp.com/ecm/ecm_download_file/ECMP1196395",
+                "https://hstechdocs.helpsystems.com/manuals/globalscape/archive/cuteftp6/open_ssl_license_agreement.htm"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/OpenVision.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/OpenVision.json",
+            "referenceNumber": 590,
+            "name": "OpenVision License",
+            "licenseId": "OpenVision",
+            "seeAlso": [
+                "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L66-L98",
+                "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html",
+                "https://fedoraproject.org/wiki/Licensing:MIT#OpenVision_Variant"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/PADL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PADL.json",
-            "referenceNumber": 344,
+            "referenceNumber": 145,
             "name": "PADL License",
             "licenseId": "PADL",
             "seeAlso": [
@@ -5648,7 +5958,7 @@
             "reference": "https://spdx.org/licenses/PDDL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
-            "referenceNumber": 436,
+            "referenceNumber": 231,
             "name": "Open Data Commons Public Domain Dedication & License 1.0",
             "licenseId": "PDDL-1.0",
             "seeAlso": [
@@ -5661,7 +5971,7 @@
             "reference": "https://spdx.org/licenses/PHP-3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
-            "referenceNumber": 522,
+            "referenceNumber": 622,
             "name": "PHP License v3.0",
             "licenseId": "PHP-3.0",
             "seeAlso": [
@@ -5674,7 +5984,7 @@
             "reference": "https://spdx.org/licenses/PHP-3.01.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
-            "referenceNumber": 343,
+            "referenceNumber": 11,
             "name": "PHP License v3.01",
             "licenseId": "PHP-3.01",
             "seeAlso": [
@@ -5687,7 +5997,7 @@
             "reference": "https://spdx.org/licenses/PSF-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
-            "referenceNumber": 112,
+            "referenceNumber": 381,
             "name": "Python Software Foundation License 2.0",
             "licenseId": "PSF-2.0",
             "seeAlso": [
@@ -5699,7 +6009,7 @@
             "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
-            "referenceNumber": 183,
+            "referenceNumber": 546,
             "name": "The Parity Public License 6.0.0",
             "licenseId": "Parity-6.0.0",
             "seeAlso": [
@@ -5711,7 +6021,7 @@
             "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
-            "referenceNumber": 91,
+            "referenceNumber": 281,
             "name": "The Parity Public License 7.0.0",
             "licenseId": "Parity-7.0.0",
             "seeAlso": [
@@ -5720,10 +6030,24 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/Pixar.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Pixar.json",
+            "referenceNumber": 240,
+            "name": "Pixar License",
+            "licenseId": "Pixar",
+            "seeAlso": [
+                "https://github.com/PixarAnimationStudios/OpenSubdiv/raw/v3_5_0/LICENSE.txt",
+                "https://graphics.pixar.com/opensubdiv/docs/license.html",
+                "https://github.com/PixarAnimationStudios/OpenSubdiv/blob/v3_5_0/opensubdiv/version.cpp#L2-L22"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/Plexus.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Plexus.json",
-            "referenceNumber": 286,
+            "referenceNumber": 354,
             "name": "Plexus Classworlds License",
             "licenseId": "Plexus",
             "seeAlso": [
@@ -5735,7 +6059,7 @@
             "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
-            "referenceNumber": 320,
+            "referenceNumber": 343,
             "name": "PolyForm Noncommercial License 1.0.0",
             "licenseId": "PolyForm-Noncommercial-1.0.0",
             "seeAlso": [
@@ -5747,7 +6071,7 @@
             "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
-            "referenceNumber": 307,
+            "referenceNumber": 455,
             "name": "PolyForm Small Business License 1.0.0",
             "licenseId": "PolyForm-Small-Business-1.0.0",
             "seeAlso": [
@@ -5759,7 +6083,7 @@
             "reference": "https://spdx.org/licenses/PostgreSQL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
-            "referenceNumber": 266,
+            "referenceNumber": 390,
             "name": "PostgreSQL License",
             "licenseId": "PostgreSQL",
             "seeAlso": [
@@ -5772,7 +6096,7 @@
             "reference": "https://spdx.org/licenses/Python-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Python-2.0.json",
-            "referenceNumber": 525,
+            "referenceNumber": 383,
             "name": "Python License 2.0",
             "licenseId": "Python-2.0",
             "seeAlso": [
@@ -5785,7 +6109,7 @@
             "reference": "https://spdx.org/licenses/Python-2.0.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
-            "referenceNumber": 350,
+            "referenceNumber": 559,
             "name": "Python License 2.0.1",
             "licenseId": "Python-2.0.1",
             "seeAlso": [
@@ -5799,7 +6123,7 @@
             "reference": "https://spdx.org/licenses/QPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
-            "referenceNumber": 292,
+            "referenceNumber": 459,
             "name": "Q Public License 1.0",
             "licenseId": "QPL-1.0",
             "seeAlso": [
@@ -5814,7 +6138,7 @@
             "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.json",
-            "referenceNumber": 355,
+            "referenceNumber": 537,
             "name": "Q Public License 1.0 - INRIA 2004 variant",
             "licenseId": "QPL-1.0-INRIA-2004",
             "seeAlso": [
@@ -5826,7 +6150,7 @@
             "reference": "https://spdx.org/licenses/Qhull.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Qhull.json",
-            "referenceNumber": 0,
+            "referenceNumber": 241,
             "name": "Qhull License",
             "licenseId": "Qhull",
             "seeAlso": [
@@ -5838,7 +6162,7 @@
             "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
-            "referenceNumber": 480,
+            "referenceNumber": 484,
             "name": "Red Hat eCos Public License v1.1",
             "licenseId": "RHeCos-1.1",
             "seeAlso": [
@@ -5851,7 +6175,7 @@
             "reference": "https://spdx.org/licenses/RPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
-            "referenceNumber": 426,
+            "referenceNumber": 613,
             "name": "Reciprocal Public License 1.1",
             "licenseId": "RPL-1.1",
             "seeAlso": [
@@ -5863,7 +6187,7 @@
             "reference": "https://spdx.org/licenses/RPL-1.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
-            "referenceNumber": 311,
+            "referenceNumber": 531,
             "name": "Reciprocal Public License 1.5",
             "licenseId": "RPL-1.5",
             "seeAlso": [
@@ -5875,7 +6199,7 @@
             "reference": "https://spdx.org/licenses/RPSL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
-            "referenceNumber": 456,
+            "referenceNumber": 168,
             "name": "RealNetworks Public Source License v1.0",
             "licenseId": "RPSL-1.0",
             "seeAlso": [
@@ -5889,7 +6213,7 @@
             "reference": "https://spdx.org/licenses/RSA-MD.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
-            "referenceNumber": 259,
+            "referenceNumber": 515,
             "name": "RSA Message-Digest License",
             "licenseId": "RSA-MD",
             "seeAlso": [
@@ -5901,7 +6225,7 @@
             "reference": "https://spdx.org/licenses/RSCPL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
-            "referenceNumber": 566,
+            "referenceNumber": 580,
             "name": "Ricoh Source Code Public License",
             "licenseId": "RSCPL",
             "seeAlso": [
@@ -5914,7 +6238,7 @@
             "reference": "https://spdx.org/licenses/Rdisc.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
-            "referenceNumber": 357,
+            "referenceNumber": 591,
             "name": "Rdisc License",
             "licenseId": "Rdisc",
             "seeAlso": [
@@ -5926,7 +6250,7 @@
             "reference": "https://spdx.org/licenses/Ruby.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Ruby.json",
-            "referenceNumber": 84,
+            "referenceNumber": 528,
             "name": "Ruby License",
             "licenseId": "Ruby",
             "seeAlso": [
@@ -5939,9 +6263,21 @@
             "reference": "https://spdx.org/licenses/SAX-PD.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
-            "referenceNumber": 231,
+            "referenceNumber": 169,
             "name": "Sax Public Domain Notice",
             "licenseId": "SAX-PD",
+            "seeAlso": [
+                "http://www.saxproject.org/copying.html"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/SAX-PD-2.0.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/SAX-PD-2.0.json",
+            "referenceNumber": 585,
+            "name": "Sax Public Domain Notice 2.0",
+            "licenseId": "SAX-PD-2.0",
             "seeAlso": [
                 "http://www.saxproject.org/copying.html"
             ],
@@ -5951,7 +6287,7 @@
             "reference": "https://spdx.org/licenses/SCEA.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SCEA.json",
-            "referenceNumber": 271,
+            "referenceNumber": 230,
             "name": "SCEA Shared Source License",
             "licenseId": "SCEA",
             "seeAlso": [
@@ -5963,7 +6299,7 @@
             "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
-            "referenceNumber": 471,
+            "referenceNumber": 25,
             "name": "SGI Free Software License B v1.0",
             "licenseId": "SGI-B-1.0",
             "seeAlso": [
@@ -5975,7 +6311,7 @@
             "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
-            "referenceNumber": 524,
+            "referenceNumber": 16,
             "name": "SGI Free Software License B v1.1",
             "licenseId": "SGI-B-1.1",
             "seeAlso": [
@@ -5987,7 +6323,7 @@
             "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
-            "referenceNumber": 193,
+            "referenceNumber": 431,
             "name": "SGI Free Software License B v2.0",
             "licenseId": "SGI-B-2.0",
             "seeAlso": [
@@ -6000,7 +6336,7 @@
             "reference": "https://spdx.org/licenses/SGI-OpenGL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SGI-OpenGL.json",
-            "referenceNumber": 226,
+            "referenceNumber": 408,
             "name": "SGI OpenGL License",
             "licenseId": "SGI-OpenGL",
             "seeAlso": [
@@ -6012,7 +6348,7 @@
             "reference": "https://spdx.org/licenses/SGP4.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SGP4.json",
-            "referenceNumber": 433,
+            "referenceNumber": 461,
             "name": "SGP4 Permission Notice",
             "licenseId": "SGP4",
             "seeAlso": [
@@ -6024,7 +6360,7 @@
             "reference": "https://spdx.org/licenses/SHL-0.5.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
-            "referenceNumber": 207,
+            "referenceNumber": 298,
             "name": "Solderpad Hardware License v0.5",
             "licenseId": "SHL-0.5",
             "seeAlso": [
@@ -6036,7 +6372,7 @@
             "reference": "https://spdx.org/licenses/SHL-0.51.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
-            "referenceNumber": 181,
+            "referenceNumber": 504,
             "name": "Solderpad Hardware License, Version 0.51",
             "licenseId": "SHL-0.51",
             "seeAlso": [
@@ -6048,7 +6384,7 @@
             "reference": "https://spdx.org/licenses/SISSL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SISSL.json",
-            "referenceNumber": 374,
+            "referenceNumber": 525,
             "name": "Sun Industry Standards Source License v1.1",
             "licenseId": "SISSL",
             "seeAlso": [
@@ -6062,7 +6398,7 @@
             "reference": "https://spdx.org/licenses/SISSL-1.2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
-            "referenceNumber": 160,
+            "referenceNumber": 493,
             "name": "Sun Industry Standards Source License v1.2",
             "licenseId": "SISSL-1.2",
             "seeAlso": [
@@ -6074,7 +6410,7 @@
             "reference": "https://spdx.org/licenses/SL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SL.json",
-            "referenceNumber": 331,
+            "referenceNumber": 190,
             "name": "SL License",
             "licenseId": "SL",
             "seeAlso": [
@@ -6086,7 +6422,7 @@
             "reference": "https://spdx.org/licenses/SMLNJ.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
-            "referenceNumber": 569,
+            "referenceNumber": 63,
             "name": "Standard ML of New Jersey License",
             "licenseId": "SMLNJ",
             "seeAlso": [
@@ -6099,7 +6435,7 @@
             "reference": "https://spdx.org/licenses/SMPPL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
-            "referenceNumber": 88,
+            "referenceNumber": 193,
             "name": "Secure Messaging Protocol Public License",
             "licenseId": "SMPPL",
             "seeAlso": [
@@ -6111,7 +6447,7 @@
             "reference": "https://spdx.org/licenses/SNIA.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SNIA.json",
-            "referenceNumber": 585,
+            "referenceNumber": 211,
             "name": "SNIA Public License 1.1",
             "licenseId": "SNIA",
             "seeAlso": [
@@ -6123,7 +6459,7 @@
             "reference": "https://spdx.org/licenses/SPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
-            "referenceNumber": 8,
+            "referenceNumber": 3,
             "name": "Sun Public License v1.0",
             "licenseId": "SPL-1.0",
             "seeAlso": [
@@ -6136,7 +6472,7 @@
             "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
-            "referenceNumber": 154,
+            "referenceNumber": 364,
             "name": "SSH OpenSSH license",
             "licenseId": "SSH-OpenSSH",
             "seeAlso": [
@@ -6148,7 +6484,7 @@
             "reference": "https://spdx.org/licenses/SSH-short.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
-            "referenceNumber": 104,
+            "referenceNumber": 428,
             "name": "SSH short notice",
             "licenseId": "SSH-short",
             "seeAlso": [
@@ -6159,10 +6495,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/SSLeay-standalone.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/SSLeay-standalone.json",
+            "referenceNumber": 419,
+            "name": "SSLeay License - standalone",
+            "licenseId": "SSLeay-standalone",
+            "seeAlso": [
+                "https://www.tq-group.com/filedownloads/files/software-license-conditions/OriginalSSLeay/OriginalSSLeay.pdf"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/SSPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
-            "referenceNumber": 412,
+            "referenceNumber": 156,
             "name": "Server Side Public License, v 1",
             "licenseId": "SSPL-1.0",
             "seeAlso": [
@@ -6174,7 +6522,7 @@
             "reference": "https://spdx.org/licenses/SWL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SWL.json",
-            "referenceNumber": 466,
+            "referenceNumber": 360,
             "name": "Scheme Widget Library (SWL) Software License Agreement",
             "licenseId": "SWL",
             "seeAlso": [
@@ -6186,7 +6534,7 @@
             "reference": "https://spdx.org/licenses/Saxpath.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
-            "referenceNumber": 45,
+            "referenceNumber": 430,
             "name": "Saxpath License",
             "licenseId": "Saxpath",
             "seeAlso": [
@@ -6198,7 +6546,7 @@
             "reference": "https://spdx.org/licenses/SchemeReport.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
-            "referenceNumber": 208,
+            "referenceNumber": 552,
             "name": "Scheme Language Report License",
             "licenseId": "SchemeReport",
             "seeAlso": [
@@ -6210,7 +6558,7 @@
             "reference": "https://spdx.org/licenses/Sendmail.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
-            "referenceNumber": 75,
+            "referenceNumber": 427,
             "name": "Sendmail License",
             "licenseId": "Sendmail",
             "seeAlso": [
@@ -6223,7 +6571,7 @@
             "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
-            "referenceNumber": 410,
+            "referenceNumber": 24,
             "name": "Sendmail License 8.23",
             "licenseId": "Sendmail-8.23",
             "seeAlso": [
@@ -6236,7 +6584,7 @@
             "reference": "https://spdx.org/licenses/SimPL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
-            "referenceNumber": 587,
+            "referenceNumber": 617,
             "name": "Simple Public License 2.0",
             "licenseId": "SimPL-2.0",
             "seeAlso": [
@@ -6248,7 +6596,7 @@
             "reference": "https://spdx.org/licenses/Sleepycat.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
-            "referenceNumber": 177,
+            "referenceNumber": 239,
             "name": "Sleepycat License",
             "licenseId": "Sleepycat",
             "seeAlso": [
@@ -6261,7 +6609,7 @@
             "reference": "https://spdx.org/licenses/Soundex.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Soundex.json",
-            "referenceNumber": 171,
+            "referenceNumber": 43,
             "name": "Soundex License",
             "licenseId": "Soundex",
             "seeAlso": [
@@ -6273,7 +6621,7 @@
             "reference": "https://spdx.org/licenses/Spencer-86.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
-            "referenceNumber": 589,
+            "referenceNumber": 469,
             "name": "Spencer License 86",
             "licenseId": "Spencer-86",
             "seeAlso": [
@@ -6285,7 +6633,7 @@
             "reference": "https://spdx.org/licenses/Spencer-94.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
-            "referenceNumber": 251,
+            "referenceNumber": 583,
             "name": "Spencer License 94",
             "licenseId": "Spencer-94",
             "seeAlso": [
@@ -6298,7 +6646,7 @@
             "reference": "https://spdx.org/licenses/Spencer-99.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
-            "referenceNumber": 176,
+            "referenceNumber": 420,
             "name": "Spencer License 99",
             "licenseId": "Spencer-99",
             "seeAlso": [
@@ -6310,7 +6658,7 @@
             "reference": "https://spdx.org/licenses/StandardML-NJ.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
-            "referenceNumber": 117,
+            "referenceNumber": 510,
             "name": "Standard ML of New Jersey License",
             "licenseId": "StandardML-NJ",
             "seeAlso": [
@@ -6323,7 +6671,7 @@
             "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
-            "referenceNumber": 297,
+            "referenceNumber": 33,
             "name": "SugarCRM Public License v1.1.3",
             "licenseId": "SugarCRM-1.1.3",
             "seeAlso": [
@@ -6332,10 +6680,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/Sun-PPP.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Sun-PPP.json",
+            "referenceNumber": 598,
+            "name": "Sun PPP License",
+            "licenseId": "Sun-PPP",
+            "seeAlso": [
+                "https://github.com/ppp-project/ppp/blob/master/pppd/eap.c#L7-L16"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/SunPro.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/SunPro.json",
-            "referenceNumber": 507,
+            "referenceNumber": 95,
             "name": "SunPro License",
             "licenseId": "SunPro",
             "seeAlso": [
@@ -6348,7 +6708,7 @@
             "reference": "https://spdx.org/licenses/Symlinks.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Symlinks.json",
-            "referenceNumber": 93,
+            "referenceNumber": 488,
             "name": "Symlinks License",
             "licenseId": "Symlinks",
             "seeAlso": [
@@ -6360,7 +6720,7 @@
             "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
-            "referenceNumber": 338,
+            "referenceNumber": 403,
             "name": "TAPR Open Hardware License v1.0",
             "licenseId": "TAPR-OHL-1.0",
             "seeAlso": [
@@ -6372,7 +6732,7 @@
             "reference": "https://spdx.org/licenses/TCL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TCL.json",
-            "referenceNumber": 523,
+            "referenceNumber": 494,
             "name": "TCL/TK License",
             "licenseId": "TCL",
             "seeAlso": [
@@ -6385,7 +6745,7 @@
             "reference": "https://spdx.org/licenses/TCP-wrappers.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
-            "referenceNumber": 129,
+            "referenceNumber": 194,
             "name": "TCP Wrappers License",
             "licenseId": "TCP-wrappers",
             "seeAlso": [
@@ -6394,10 +6754,23 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/TGPPL-1.0.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/TGPPL-1.0.json",
+            "referenceNumber": 208,
+            "name": "Transitive Grace Period Public Licence 1.0",
+            "licenseId": "TGPPL-1.0",
+            "seeAlso": [
+                "https://fedoraproject.org/wiki/Licensing/TGPPL",
+                "https://tahoe-lafs.org/trac/tahoe-lafs/browser/trunk/COPYING.TGPPL.rst"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/TMate.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TMate.json",
-            "referenceNumber": 312,
+            "referenceNumber": 541,
             "name": "TMate Open Source License",
             "licenseId": "TMate",
             "seeAlso": [
@@ -6409,7 +6782,7 @@
             "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
-            "referenceNumber": 111,
+            "referenceNumber": 332,
             "name": "TORQUE v2.5+ Software License v1.1",
             "licenseId": "TORQUE-1.1",
             "seeAlso": [
@@ -6421,7 +6794,7 @@
             "reference": "https://spdx.org/licenses/TOSL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TOSL.json",
-            "referenceNumber": 106,
+            "referenceNumber": 574,
             "name": "Trusster Open Source License",
             "licenseId": "TOSL",
             "seeAlso": [
@@ -6433,7 +6806,7 @@
             "reference": "https://spdx.org/licenses/TPDL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TPDL.json",
-            "referenceNumber": 571,
+            "referenceNumber": 302,
             "name": "Time::ParseDate License",
             "licenseId": "TPDL",
             "seeAlso": [
@@ -6445,7 +6818,7 @@
             "reference": "https://spdx.org/licenses/TPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TPL-1.0.json",
-            "referenceNumber": 161,
+            "referenceNumber": 134,
             "name": "THOR Public License 1.0",
             "licenseId": "TPL-1.0",
             "seeAlso": [
@@ -6457,7 +6830,7 @@
             "reference": "https://spdx.org/licenses/TTWL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TTWL.json",
-            "referenceNumber": 465,
+            "referenceNumber": 28,
             "name": "Text-Tabs+Wrap License",
             "licenseId": "TTWL",
             "seeAlso": [
@@ -6470,7 +6843,7 @@
             "reference": "https://spdx.org/licenses/TTYP0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TTYP0.json",
-            "referenceNumber": 548,
+            "referenceNumber": 207,
             "name": "TTYP0 License",
             "licenseId": "TTYP0",
             "seeAlso": [
@@ -6482,7 +6855,7 @@
             "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
-            "referenceNumber": 568,
+            "referenceNumber": 98,
             "name": "Technische Universitaet Berlin License 1.0",
             "licenseId": "TU-Berlin-1.0",
             "seeAlso": [
@@ -6494,7 +6867,7 @@
             "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
-            "referenceNumber": 43,
+            "referenceNumber": 533,
             "name": "Technische Universitaet Berlin License 2.0",
             "licenseId": "TU-Berlin-2.0",
             "seeAlso": [
@@ -6506,7 +6879,7 @@
             "reference": "https://spdx.org/licenses/TermReadKey.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/TermReadKey.json",
-            "referenceNumber": 402,
+            "referenceNumber": 412,
             "name": "TermReadKey License",
             "licenseId": "TermReadKey",
             "seeAlso": [
@@ -6518,7 +6891,7 @@
             "reference": "https://spdx.org/licenses/UCAR.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/UCAR.json",
-            "referenceNumber": 283,
+            "referenceNumber": 371,
             "name": "UCAR License",
             "licenseId": "UCAR",
             "seeAlso": [
@@ -6530,7 +6903,7 @@
             "reference": "https://spdx.org/licenses/UCL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
-            "referenceNumber": 145,
+            "referenceNumber": 88,
             "name": "Upstream Compatibility License v1.0",
             "licenseId": "UCL-1.0",
             "seeAlso": [
@@ -6539,10 +6912,22 @@
             "isOsiApproved": true
         },
         {
+            "reference": "https://spdx.org/licenses/UMich-Merit.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/UMich-Merit.json",
+            "referenceNumber": 413,
+            "name": "Michigan/Merit Networks License",
+            "licenseId": "UMich-Merit",
+            "seeAlso": [
+                "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L64"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/UPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
-            "referenceNumber": 288,
+            "referenceNumber": 165,
             "name": "Universal Permissive License v1.0",
             "licenseId": "UPL-1.0",
             "seeAlso": [
@@ -6555,7 +6940,7 @@
             "reference": "https://spdx.org/licenses/URT-RLE.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/URT-RLE.json",
-            "referenceNumber": 495,
+            "referenceNumber": 416,
             "name": "Utah Raster Toolkit Run Length Encoded License",
             "licenseId": "URT-RLE",
             "seeAlso": [
@@ -6565,10 +6950,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/Unicode-3.0.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/Unicode-3.0.json",
+            "referenceNumber": 287,
+            "name": "Unicode License v3",
+            "licenseId": "Unicode-3.0",
+            "seeAlso": [
+                "https://www.unicode.org/license.txt"
+            ],
+            "isOsiApproved": true
+        },
+        {
             "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
-            "referenceNumber": 430,
+            "referenceNumber": 137,
             "name": "Unicode License Agreement - Data Files and Software (2015)",
             "licenseId": "Unicode-DFS-2015",
             "seeAlso": [
@@ -6580,7 +6977,7 @@
             "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
-            "referenceNumber": 316,
+            "referenceNumber": 295,
             "name": "Unicode License Agreement - Data Files and Software (2016)",
             "licenseId": "Unicode-DFS-2016",
             "seeAlso": [
@@ -6594,7 +6991,7 @@
             "reference": "https://spdx.org/licenses/Unicode-TOU.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
-            "referenceNumber": 328,
+            "referenceNumber": 432,
             "name": "Unicode Terms of Use",
             "licenseId": "Unicode-TOU",
             "seeAlso": [
@@ -6607,7 +7004,7 @@
             "reference": "https://spdx.org/licenses/UnixCrypt.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/UnixCrypt.json",
-            "referenceNumber": 437,
+            "referenceNumber": 275,
             "name": "UnixCrypt License",
             "licenseId": "UnixCrypt",
             "seeAlso": [
@@ -6621,7 +7018,7 @@
             "reference": "https://spdx.org/licenses/Unlicense.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
-            "referenceNumber": 377,
+            "referenceNumber": 58,
             "name": "The Unlicense",
             "licenseId": "Unlicense",
             "seeAlso": [
@@ -6634,7 +7031,7 @@
             "reference": "https://spdx.org/licenses/VOSTROM.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
-            "referenceNumber": 517,
+            "referenceNumber": 516,
             "name": "VOSTROM Public License for Open Source",
             "licenseId": "VOSTROM",
             "seeAlso": [
@@ -6646,7 +7043,7 @@
             "reference": "https://spdx.org/licenses/VSL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
-            "referenceNumber": 298,
+            "referenceNumber": 440,
             "name": "Vovida Software License v1.0",
             "licenseId": "VSL-1.0",
             "seeAlso": [
@@ -6658,7 +7055,7 @@
             "reference": "https://spdx.org/licenses/Vim.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Vim.json",
-            "referenceNumber": 489,
+            "referenceNumber": 296,
             "name": "Vim License",
             "licenseId": "Vim",
             "seeAlso": [
@@ -6671,7 +7068,7 @@
             "reference": "https://spdx.org/licenses/W3C.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/W3C.json",
-            "referenceNumber": 173,
+            "referenceNumber": 13,
             "name": "W3C Software Notice and License (2002-12-31)",
             "licenseId": "W3C",
             "seeAlso": [
@@ -6685,7 +7082,7 @@
             "reference": "https://spdx.org/licenses/W3C-19980720.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
-            "referenceNumber": 172,
+            "referenceNumber": 625,
             "name": "W3C Software Notice and License (1998-07-20)",
             "licenseId": "W3C-19980720",
             "seeAlso": [
@@ -6697,7 +7094,7 @@
             "reference": "https://spdx.org/licenses/W3C-20150513.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
-            "referenceNumber": 485,
+            "referenceNumber": 524,
             "name": "W3C Software Notice and Document License (2015-05-13)",
             "licenseId": "W3C-20150513",
             "seeAlso": [
@@ -6709,7 +7106,7 @@
             "reference": "https://spdx.org/licenses/WTFPL.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
-            "referenceNumber": 508,
+            "referenceNumber": 315,
             "name": "Do What The F*ck You Want To Public License",
             "licenseId": "WTFPL",
             "seeAlso": [
@@ -6723,7 +7120,7 @@
             "reference": "https://spdx.org/licenses/Watcom-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
-            "referenceNumber": 16,
+            "referenceNumber": 81,
             "name": "Sybase Open Watcom Public License 1.0",
             "licenseId": "Watcom-1.0",
             "seeAlso": [
@@ -6736,7 +7133,7 @@
             "reference": "https://spdx.org/licenses/Widget-Workshop.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Widget-Workshop.json",
-            "referenceNumber": 425,
+            "referenceNumber": 503,
             "name": "Widget Workshop License",
             "licenseId": "Widget-Workshop",
             "seeAlso": [
@@ -6748,7 +7145,7 @@
             "reference": "https://spdx.org/licenses/Wsuipa.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
-            "referenceNumber": 527,
+            "referenceNumber": 612,
             "name": "Wsuipa License",
             "licenseId": "Wsuipa",
             "seeAlso": [
@@ -6760,7 +7157,7 @@
             "reference": "https://spdx.org/licenses/X11.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/X11.json",
-            "referenceNumber": 51,
+            "referenceNumber": 518,
             "name": "X11 License",
             "licenseId": "X11",
             "seeAlso": [
@@ -6773,7 +7170,7 @@
             "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
-            "referenceNumber": 369,
+            "referenceNumber": 587,
             "name": "X11 License Distribution Modification Variant",
             "licenseId": "X11-distribute-modifications-variant",
             "seeAlso": [
@@ -6785,7 +7182,7 @@
             "reference": "https://spdx.org/licenses/XFree86-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
-            "referenceNumber": 282,
+            "referenceNumber": 247,
             "name": "XFree86 License 1.1",
             "licenseId": "XFree86-1.1",
             "seeAlso": [
@@ -6798,7 +7195,7 @@
             "reference": "https://spdx.org/licenses/XSkat.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/XSkat.json",
-            "referenceNumber": 32,
+            "referenceNumber": 356,
             "name": "XSkat License",
             "licenseId": "XSkat",
             "seeAlso": [
@@ -6810,7 +7207,7 @@
             "reference": "https://spdx.org/licenses/Xdebug-1.03.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Xdebug-1.03.json",
-            "referenceNumber": 521,
+            "referenceNumber": 198,
             "name": "Xdebug License v 1.03",
             "licenseId": "Xdebug-1.03",
             "seeAlso": [
@@ -6822,7 +7219,7 @@
             "reference": "https://spdx.org/licenses/Xerox.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Xerox.json",
-            "referenceNumber": 359,
+            "referenceNumber": 320,
             "name": "Xerox License",
             "licenseId": "Xerox",
             "seeAlso": [
@@ -6834,7 +7231,7 @@
             "reference": "https://spdx.org/licenses/Xfig.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Xfig.json",
-            "referenceNumber": 148,
+            "referenceNumber": 171,
             "name": "Xfig License",
             "licenseId": "Xfig",
             "seeAlso": [
@@ -6848,7 +7245,7 @@
             "reference": "https://spdx.org/licenses/Xnet.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Xnet.json",
-            "referenceNumber": 273,
+            "referenceNumber": 125,
             "name": "X.Net License",
             "licenseId": "Xnet",
             "seeAlso": [
@@ -6860,7 +7257,7 @@
             "reference": "https://spdx.org/licenses/YPL-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
-            "referenceNumber": 263,
+            "referenceNumber": 27,
             "name": "Yahoo! Public License v1.0",
             "licenseId": "YPL-1.0",
             "seeAlso": [
@@ -6872,7 +7269,7 @@
             "reference": "https://spdx.org/licenses/YPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
-            "referenceNumber": 70,
+            "referenceNumber": 170,
             "name": "Yahoo! Public License v1.1",
             "licenseId": "YPL-1.1",
             "seeAlso": [
@@ -6885,7 +7282,7 @@
             "reference": "https://spdx.org/licenses/ZPL-1.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
-            "referenceNumber": 497,
+            "referenceNumber": 79,
             "name": "Zope Public License 1.1",
             "licenseId": "ZPL-1.1",
             "seeAlso": [
@@ -6897,7 +7294,7 @@
             "reference": "https://spdx.org/licenses/ZPL-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
-            "referenceNumber": 46,
+            "referenceNumber": 629,
             "name": "Zope Public License 2.0",
             "licenseId": "ZPL-2.0",
             "seeAlso": [
@@ -6911,7 +7308,7 @@
             "reference": "https://spdx.org/licenses/ZPL-2.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
-            "referenceNumber": 39,
+            "referenceNumber": 301,
             "name": "Zope Public License 2.1",
             "licenseId": "ZPL-2.1",
             "seeAlso": [
@@ -6924,7 +7321,7 @@
             "reference": "https://spdx.org/licenses/Zed.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Zed.json",
-            "referenceNumber": 479,
+            "referenceNumber": 505,
             "name": "Zed License",
             "licenseId": "Zed",
             "seeAlso": [
@@ -6936,7 +7333,7 @@
             "reference": "https://spdx.org/licenses/Zeeff.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Zeeff.json",
-            "referenceNumber": 222,
+            "referenceNumber": 177,
             "name": "Zeeff License",
             "licenseId": "Zeeff",
             "seeAlso": [
@@ -6948,7 +7345,7 @@
             "reference": "https://spdx.org/licenses/Zend-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
-            "referenceNumber": 300,
+            "referenceNumber": 290,
             "name": "Zend License v2.0",
             "licenseId": "Zend-2.0",
             "seeAlso": [
@@ -6961,7 +7358,7 @@
             "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
-            "referenceNumber": 434,
+            "referenceNumber": 561,
             "name": "Zimbra Public License v1.3",
             "licenseId": "Zimbra-1.3",
             "seeAlso": [
@@ -6974,7 +7371,7 @@
             "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
-            "referenceNumber": 215,
+            "referenceNumber": 185,
             "name": "Zimbra Public License v1.4",
             "licenseId": "Zimbra-1.4",
             "seeAlso": [
@@ -6986,7 +7383,7 @@
             "reference": "https://spdx.org/licenses/Zlib.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/Zlib.json",
-            "referenceNumber": 294,
+            "referenceNumber": 606,
             "name": "zlib License",
             "licenseId": "Zlib",
             "seeAlso": [
@@ -6997,10 +7394,22 @@
             "isFsfLibre": true
         },
         {
+            "reference": "https://spdx.org/licenses/bcrypt-Solar-Designer.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/bcrypt-Solar-Designer.json",
+            "referenceNumber": 166,
+            "name": "bcrypt Solar Designer License",
+            "licenseId": "bcrypt-Solar-Designer",
+            "seeAlso": [
+                "https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/ext/mri/crypt_blowfish.c"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/blessing.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/blessing.json",
-            "referenceNumber": 153,
+            "referenceNumber": 618,
             "name": "SQLite Blessing",
             "licenseId": "blessing",
             "seeAlso": [
@@ -7013,7 +7422,7 @@
             "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
-            "referenceNumber": 371,
+            "referenceNumber": 283,
             "name": "bzip2 and libbzip2 License v1.0.5",
             "licenseId": "bzip2-1.0.5",
             "seeAlso": [
@@ -7026,12 +7435,13 @@
             "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
-            "referenceNumber": 520,
+            "referenceNumber": 206,
             "name": "bzip2 and libbzip2 License v1.0.6",
             "licenseId": "bzip2-1.0.6",
             "seeAlso": [
                 "https://sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=bzip2-1.0.6",
-                "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+                "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html",
+                "https://sourceware.org/cgit/valgrind/tree/mpi/libmpiwrap.c"
             ],
             "isOsiApproved": false
         },
@@ -7039,7 +7449,7 @@
             "reference": "https://spdx.org/licenses/check-cvs.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/check-cvs.json",
-            "referenceNumber": 564,
+            "referenceNumber": 334,
             "name": "check-cvs License",
             "licenseId": "check-cvs",
             "seeAlso": [
@@ -7051,7 +7461,7 @@
             "reference": "https://spdx.org/licenses/checkmk.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/checkmk.json",
-            "referenceNumber": 240,
+            "referenceNumber": 111,
             "name": "Checkmk License",
             "licenseId": "checkmk",
             "seeAlso": [
@@ -7063,7 +7473,7 @@
             "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
-            "referenceNumber": 20,
+            "referenceNumber": 340,
             "name": "copyleft-next 0.3.0",
             "licenseId": "copyleft-next-0.3.0",
             "seeAlso": [
@@ -7075,7 +7485,7 @@
             "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
-            "referenceNumber": 284,
+            "referenceNumber": 553,
             "name": "copyleft-next 0.3.1",
             "licenseId": "copyleft-next-0.3.1",
             "seeAlso": [
@@ -7087,7 +7497,7 @@
             "reference": "https://spdx.org/licenses/curl.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/curl.json",
-            "referenceNumber": 399,
+            "referenceNumber": 429,
             "name": "curl License",
             "licenseId": "curl",
             "seeAlso": [
@@ -7099,7 +7509,7 @@
             "reference": "https://spdx.org/licenses/diffmark.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/diffmark.json",
-            "referenceNumber": 220,
+            "referenceNumber": 365,
             "name": "diffmark license",
             "licenseId": "diffmark",
             "seeAlso": [
@@ -7111,7 +7521,7 @@
             "reference": "https://spdx.org/licenses/dtoa.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/dtoa.json",
-            "referenceNumber": 561,
+            "referenceNumber": 74,
             "name": "David M. Gay dtoa License",
             "licenseId": "dtoa",
             "seeAlso": [
@@ -7123,7 +7533,7 @@
             "reference": "https://spdx.org/licenses/dvipdfm.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
-            "referenceNumber": 195,
+            "referenceNumber": 309,
             "name": "dvipdfm License",
             "licenseId": "dvipdfm",
             "seeAlso": [
@@ -7135,7 +7545,7 @@
             "reference": "https://spdx.org/licenses/eCos-2.0.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
-            "referenceNumber": 73,
+            "referenceNumber": 173,
             "name": "eCos license version 2.0",
             "licenseId": "eCos-2.0",
             "seeAlso": [
@@ -7148,7 +7558,7 @@
             "reference": "https://spdx.org/licenses/eGenix.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/eGenix.json",
-            "referenceNumber": 319,
+            "referenceNumber": 102,
             "name": "eGenix.com Public License 1.1.0",
             "licenseId": "eGenix",
             "seeAlso": [
@@ -7161,7 +7571,7 @@
             "reference": "https://spdx.org/licenses/etalab-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
-            "referenceNumber": 19,
+            "referenceNumber": 299,
             "name": "Etalab Open License 2.0",
             "licenseId": "etalab-2.0",
             "seeAlso": [
@@ -7174,7 +7584,7 @@
             "reference": "https://spdx.org/licenses/fwlw.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/fwlw.json",
-            "referenceNumber": 24,
+            "referenceNumber": 258,
             "name": "fwlw License",
             "licenseId": "fwlw",
             "seeAlso": [
@@ -7186,7 +7596,7 @@
             "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
-            "referenceNumber": 596,
+            "referenceNumber": 633,
             "name": "gSOAP Public License v1.3b",
             "licenseId": "gSOAP-1.3b",
             "seeAlso": [
@@ -7198,7 +7608,7 @@
             "reference": "https://spdx.org/licenses/gnuplot.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
-            "referenceNumber": 230,
+            "referenceNumber": 268,
             "name": "gnuplot License",
             "licenseId": "gnuplot",
             "seeAlso": [
@@ -7208,10 +7618,35 @@
             "isFsfLibre": true
         },
         {
+            "reference": "https://spdx.org/licenses/gtkbook.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/gtkbook.json",
+            "referenceNumber": 341,
+            "name": "gtkbook License",
+            "licenseId": "gtkbook",
+            "seeAlso": [
+                "https://github.com/slogan621/gtkbook",
+                "https://github.com/oetiker/rrdtool-1.x/blob/master/src/plbasename.c#L8-L11"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/hdparm.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/hdparm.json",
+            "referenceNumber": 467,
+            "name": "hdparm License",
+            "licenseId": "hdparm",
+            "seeAlso": [
+                "https://github.com/Distrotech/hdparm/blob/4517550db29a91420fb2b020349523b1b4512df2/LICENSE.TXT"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/iMatix.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/iMatix.json",
-            "referenceNumber": 493,
+            "referenceNumber": 307,
             "name": "iMatix Standard Function Library Agreement",
             "licenseId": "iMatix",
             "seeAlso": [
@@ -7224,7 +7659,7 @@
             "reference": "https://spdx.org/licenses/libpng-2.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
-            "referenceNumber": 293,
+            "referenceNumber": 212,
             "name": "PNG Reference Library version 2",
             "licenseId": "libpng-2.0",
             "seeAlso": [
@@ -7236,7 +7671,7 @@
             "reference": "https://spdx.org/licenses/libselinux-1.0.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
-            "referenceNumber": 353,
+            "referenceNumber": 266,
             "name": "libselinux public domain notice",
             "licenseId": "libselinux-1.0",
             "seeAlso": [
@@ -7248,7 +7683,7 @@
             "reference": "https://spdx.org/licenses/libtiff.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/libtiff.json",
-            "referenceNumber": 313,
+            "referenceNumber": 20,
             "name": "libtiff License",
             "licenseId": "libtiff",
             "seeAlso": [
@@ -7260,7 +7695,7 @@
             "reference": "https://spdx.org/licenses/libutil-David-Nugent.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/libutil-David-Nugent.json",
-            "referenceNumber": 270,
+            "referenceNumber": 393,
             "name": "libutil David Nugent License",
             "licenseId": "libutil-David-Nugent",
             "seeAlso": [
@@ -7273,7 +7708,7 @@
             "reference": "https://spdx.org/licenses/lsof.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/lsof.json",
-            "referenceNumber": 162,
+            "referenceNumber": 157,
             "name": "lsof License",
             "licenseId": "lsof",
             "seeAlso": [
@@ -7285,7 +7720,7 @@
             "reference": "https://spdx.org/licenses/magaz.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/magaz.json",
-            "referenceNumber": 442,
+            "referenceNumber": 279,
             "name": "magaz License",
             "licenseId": "magaz",
             "seeAlso": [
@@ -7294,10 +7729,22 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/mailprio.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/mailprio.json",
+            "referenceNumber": 225,
+            "name": "mailprio License",
+            "licenseId": "mailprio",
+            "seeAlso": [
+                "https://fossies.org/linux/sendmail/contrib/mailprio"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/metamail.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/metamail.json",
-            "referenceNumber": 165,
+            "referenceNumber": 567,
             "name": "metamail License",
             "licenseId": "metamail",
             "seeAlso": [
@@ -7309,7 +7756,7 @@
             "reference": "https://spdx.org/licenses/mpi-permissive.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
-            "referenceNumber": 565,
+            "referenceNumber": 114,
             "name": "mpi Permissive License",
             "licenseId": "mpi-permissive",
             "seeAlso": [
@@ -7321,7 +7768,7 @@
             "reference": "https://spdx.org/licenses/mpich2.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/mpich2.json",
-            "referenceNumber": 6,
+            "referenceNumber": 164,
             "name": "mpich2 License",
             "licenseId": "mpich2",
             "seeAlso": [
@@ -7333,7 +7780,7 @@
             "reference": "https://spdx.org/licenses/mplus.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/mplus.json",
-            "referenceNumber": 22,
+            "referenceNumber": 160,
             "name": "mplus Font License",
             "licenseId": "mplus",
             "seeAlso": [
@@ -7345,7 +7792,7 @@
             "reference": "https://spdx.org/licenses/pnmstitch.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/pnmstitch.json",
-            "referenceNumber": 372,
+            "referenceNumber": 76,
             "name": "pnmstitch License",
             "licenseId": "pnmstitch",
             "seeAlso": [
@@ -7357,7 +7804,7 @@
             "reference": "https://spdx.org/licenses/psfrag.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/psfrag.json",
-            "referenceNumber": 126,
+            "referenceNumber": 150,
             "name": "psfrag License",
             "licenseId": "psfrag",
             "seeAlso": [
@@ -7369,7 +7816,7 @@
             "reference": "https://spdx.org/licenses/psutils.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/psutils.json",
-            "referenceNumber": 536,
+            "referenceNumber": 146,
             "name": "psutils License",
             "licenseId": "psutils",
             "seeAlso": [
@@ -7381,12 +7828,23 @@
             "reference": "https://spdx.org/licenses/python-ldap.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/python-ldap.json",
-            "referenceNumber": 96,
+            "referenceNumber": 581,
             "name": "Python ldap License",
             "licenseId": "python-ldap",
             "seeAlso": [
-                "https://github.com/zdohnal/hplip/blob/master/base/ldif.py",
-                "https://sourceforge.net/projects/hplip/files/hplip/3.23.5/hplip-3.23.5.tar.gz/download"
+                "https://github.com/python-ldap/python-ldap/blob/main/LICENCE"
+            ],
+            "isOsiApproved": false
+        },
+        {
+            "reference": "https://spdx.org/licenses/radvd.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/radvd.json",
+            "referenceNumber": 5,
+            "name": "radvd License",
+            "licenseId": "radvd",
+            "seeAlso": [
+                "https://github.com/radvd-project/radvd/blob/master/COPYRIGHT"
             ],
             "isOsiApproved": false
         },
@@ -7394,7 +7852,7 @@
             "reference": "https://spdx.org/licenses/snprintf.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/snprintf.json",
-            "referenceNumber": 79,
+            "referenceNumber": 159,
             "name": "snprintf License",
             "licenseId": "snprintf",
             "seeAlso": [
@@ -7403,10 +7861,23 @@
             "isOsiApproved": false
         },
         {
+            "reference": "https://spdx.org/licenses/softSurfer.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/softSurfer.json",
+            "referenceNumber": 489,
+            "name": "softSurfer License",
+            "licenseId": "softSurfer",
+            "seeAlso": [
+                "https://github.com/mm2/Little-CMS/blob/master/src/cmssm.c#L207",
+                "https://fedoraproject.org/wiki/Licensing/softSurfer"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/ssh-keyscan.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ssh-keyscan.json",
-            "referenceNumber": 170,
+            "referenceNumber": 84,
             "name": "ssh-keyscan License",
             "licenseId": "ssh-keyscan",
             "seeAlso": [
@@ -7418,7 +7889,7 @@
             "reference": "https://spdx.org/licenses/swrule.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/swrule.json",
-            "referenceNumber": 278,
+            "referenceNumber": 362,
             "name": "swrule License",
             "licenseId": "swrule",
             "seeAlso": [
@@ -7430,7 +7901,7 @@
             "reference": "https://spdx.org/licenses/ulem.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/ulem.json",
-            "referenceNumber": 187,
+            "referenceNumber": 401,
             "name": "ulem License",
             "licenseId": "ulem",
             "seeAlso": [
@@ -7442,7 +7913,7 @@
             "reference": "https://spdx.org/licenses/w3m.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/w3m.json",
-            "referenceNumber": 370,
+            "referenceNumber": 509,
             "name": "w3m License",
             "licenseId": "w3m",
             "seeAlso": [
@@ -7454,7 +7925,7 @@
             "reference": "https://spdx.org/licenses/wxWindows.html",
             "isDeprecatedLicenseId": true,
             "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
-            "referenceNumber": 57,
+            "referenceNumber": 274,
             "name": "wxWindows Library License",
             "licenseId": "wxWindows",
             "seeAlso": [
@@ -7466,7 +7937,7 @@
             "reference": "https://spdx.org/licenses/xinetd.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/xinetd.json",
-            "referenceNumber": 188,
+            "referenceNumber": 17,
             "name": "xinetd License",
             "licenseId": "xinetd",
             "seeAlso": [
@@ -7476,10 +7947,22 @@
             "isFsfLibre": true
         },
         {
+            "reference": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.html",
+            "isDeprecatedLicenseId": false,
+            "detailsUrl": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.json",
+            "referenceNumber": 445,
+            "name": "xkeyboard-config Zinoviev License",
+            "licenseId": "xkeyboard-config-Zinoviev",
+            "seeAlso": [
+                "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/master/COPYING?ref_type=heads#L178"
+            ],
+            "isOsiApproved": false
+        },
+        {
             "reference": "https://spdx.org/licenses/xlock.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/xlock.json",
-            "referenceNumber": 515,
+            "referenceNumber": 361,
             "name": "xlock License",
             "licenseId": "xlock",
             "seeAlso": [
@@ -7491,7 +7974,7 @@
             "reference": "https://spdx.org/licenses/xpp.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/xpp.json",
-            "referenceNumber": 513,
+            "referenceNumber": 55,
             "name": "XPP License",
             "licenseId": "xpp",
             "seeAlso": [
@@ -7503,7 +7986,7 @@
             "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
             "isDeprecatedLicenseId": false,
             "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
-            "referenceNumber": 490,
+            "referenceNumber": 560,
             "name": "zlib/libpng License with Acknowledgement",
             "licenseId": "zlib-acknowledgement",
             "seeAlso": [
@@ -7512,5 +7995,5 @@
             "isOsiApproved": false
         }
     ],
-    "releaseDate": "2023-10-05"
+    "releaseDate": "2024-02-08"
 }


### PR DESCRIPTION
I complained on the last update that they didn't sort like they promised. But I was wrong–they _did_ sort. It's only now on our second post-sort update that we see the granular diff as a result of that. Yay!