### PR TITLE
Add https://opensource.org/licenses/MIT as a fallback URL for MIT

### DIFF
--- a/src/main/kotlin/app/cash/licensee/licensesFallback.kt
+++ b/src/main/kotlin/app/cash/licensee/licensesFallback.kt
@@ -47,6 +47,7 @@ internal val fallbackUrls = buildMap {
     add("http://www.opensource.org/licenses/mit-license.php")
     add("https://www.opensource.org/licenses/mit-license.php")
     add("http://opensource.org/licenses/MIT")
+    add("https://opensource.org/licenses/MIT")
     add("http://api.github.com/licenses/mit")
     add("https://api.github.com/licenses/mit")
   }


### PR DESCRIPTION
Fixes https://github.com/cashapp/licensee/issues/322