### PR TITLE
Tweak GH release step a bit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -26,9 +27,11 @@ jobs:
       - name: Extract release notes
         id: extract-release-notes
         uses: ffurrer2/extract-release-notes@v2
+        with:
+          release_notes_file: RELEASE_NOTES.md
 
-      - name: Create release
-        run: gh release create --notes '${{ steps.extract-release-notes.outputs.release_notes }}' --title ${{ github.ref_name }} ${{ github.ref_name }}
+      - name: Create GitHub release
+        run: gh release create ${{ github.ref_name }} --notes-file RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Rename the step.
- Grant write permission to the contents to ensure releases are published correctly.
- The `--title` option is redundant, as the title defaults to the tag name when both are identical.
- Prefer using `--notes-file` over `--notes` to avoid issues like https://github.com/ffurrer2/extract-release-notes/issues/349.