### PR TITLE
Add missing curly bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A reason string can be supplied to document why the URL is allowed.
 licensee {
   allowUrl('https://example.com/license.html') {
     because 'Apache-2.0, but self-hosted copy of the license'
+  }
 }
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a closing brace to the `licensee` block to properly terminate the code snippet.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R175): Added a closing brace to the `licensee` block.