### PR TITLE
Exclude kotlin-stdlib from plugin dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,11 @@ POM_DEVELOPER_ID=cashapp
 POM_DEVELOPER_NAME=CashApp
 POM_DEVELOPER_URL=https://github.com/cashapp/
 
+
+# Omit automatic compile dependency on kotlin-stdlib
+# https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false
+
 systemProp.org.gradle.internal.http.socketTimeout=120000
 
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:kotlin

Run `diff licensee-gradle-plugin-1.13.0-SNAPSHOT.module.before licensee-gradle-plugin-1.13.0-SNAPSHOT.module.after`:

```diff
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
<           }
<         }
<       ],
74,80d64
<         },
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.10"
<           }
```