### PR TITLE
Check the Gradle distribution checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
It is generally a good idea to ensure the integrity of the Gradle distribution to prevent MITM attacks when downloading. (See https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification)

Renovate automatically updates this.