### PR TITLE
Add https://opensource.org/license/apache-2-0 to Apache-2.0 license URLs

### DIFF
--- a/gradle/build-logic/src/main/kotlin/app/cash/licensee/defaultFallbackUrls.kt
+++ b/gradle/build-logic/src/main/kotlin/app/cash/licensee/defaultFallbackUrls.kt
@@ -26,6 +26,7 @@ internal val defaultFallbackUrls: FallbackBuilder.() -> Unit = {
     add("http://www.apache.org/licenses/LICENSE-2.0")
     add("http://api.github.com/licenses/apache-2.0")
     add("https://api.github.com/licenses/apache-2.0")
+    add("https://opensource.org/license/apache-2-0")
   }
   putLicense("CC0-1.0") {
     add("http://creativecommons.org/publicdomain/zero/1.0/")


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cashapp/licensee/pull/425?shareId=99e40f73-939d-4883-aac8-63f70ca6683b).