### PR TITLE
Remove toolchain helper

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,6 @@ pluginManagement {
 
 plugins {
   id "app.cash.licensee.repos"
-  id "org.gradle.toolchains.foojay-resolver-convention" version "0.9.0"
 }
 
 rootProject.name = 'licensee'


### PR DESCRIPTION
We don't use toolchains. Don't need 'em, don't want 'em.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
