### PR TITLE
Correct attribute type parameter nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/licensee/compare/1.13.0...HEAD]
 
-Nothing yet!
+**Changed**
+
+- Add support for usage with Gradle 9.
 
 
 ## [1.13.0] - 2025-03-20

--- a/src/main/kotlin/app/cash/licensee/task.kt
+++ b/src/main/kotlin/app/cash/licensee/task.kt
@@ -164,7 +164,7 @@ abstract class LicenseeTask : DefaultTask() {
           val variantAttrs = variant.attributes
           for (attrs in variantAttrs.keySet()) {
             @Suppress("UNCHECKED_CAST")
-            it.attribute(attrs as Attribute<Any?>, variantAttrs.getAttribute(attrs)!!)
+            it.attribute(attrs as Attribute<Any>, variantAttrs.getAttribute(attrs)!!)
           }
         }
       }


### PR DESCRIPTION
This fails to compile with Gradle 9.

Closes #443 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
