### PR TITLE
Remove Gradle 9 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/licensee/compare/1.13.0...HEAD]
 
-**Changed**
-
-- Add support for usage with Gradle 9.
+Nothing yet!
 
 
 ## [1.13.0] - 2025-03-20


### PR DESCRIPTION
This only affects our building, not consumers.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
