### PR TITLE
Bump minimum-supported Gradle version to 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/licensee/compare/1.14.0...HEAD]
 
-Nothing yet!
+**Changed**
+
+- The minimum-supported Gradle version is now 9.0.
 
 
 ## [1.14.0] - 2025-10-07

--- a/api/licensee.api
+++ b/api/licensee.api
@@ -14,13 +14,13 @@ public final class app/cash/licensee/ArtifactDetail {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class app/cash/licensee/ArtifactDetail$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class app/cash/licensee/ArtifactDetail$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lapp/cash/licensee/ArtifactDetail$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/ArtifactDetail;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/ArtifactDetail;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/ArtifactDetail;)V
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/ArtifactDetail;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
@@ -37,13 +37,13 @@ public final class app/cash/licensee/ArtifactScm {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class app/cash/licensee/ArtifactScm$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class app/cash/licensee/ArtifactScm$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lapp/cash/licensee/ArtifactScm$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/ArtifactScm;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/ArtifactScm;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/ArtifactScm;)V
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/ArtifactScm;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
@@ -831,13 +831,13 @@ public final class app/cash/licensee/SpdxLicense {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class app/cash/licensee/SpdxLicense$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class app/cash/licensee/SpdxLicense$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lapp/cash/licensee/SpdxLicense$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/SpdxLicense;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/SpdxLicense;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/SpdxLicense;)V
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/SpdxLicense;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
@@ -855,13 +855,13 @@ public final class app/cash/licensee/UnknownLicense {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class app/cash/licensee/UnknownLicense$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class app/cash/licensee/UnknownLicense$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lapp/cash/licensee/UnknownLicense$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/UnknownLicense;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/licensee/UnknownLicense;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/UnknownLicense;)V
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/licensee/UnknownLicense;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 }
 
@@ -872,6 +872,7 @@ public final class app/cash/licensee/UnknownLicense$Companion {
 public final class app/cash/licensee/UnusedAction : java/lang/Enum {
 	public static final field IGNORE Lapp/cash/licensee/UnusedAction;
 	public static final field LOG Lapp/cash/licensee/UnusedAction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lapp/cash/licensee/UnusedAction;
 	public static fun values ()[Lapp/cash/licensee/UnusedAction;
 }
@@ -880,6 +881,7 @@ public final class app/cash/licensee/ViolationAction : java/lang/Enum {
 	public static final field FAIL Lapp/cash/licensee/ViolationAction;
 	public static final field IGNORE Lapp/cash/licensee/ViolationAction;
 	public static final field LOG Lapp/cash/licensee/ViolationAction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lapp/cash/licensee/ViolationAction;
 	public static fun values ()[Lapp/cash/licensee/ViolationAction;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -61,7 +62,7 @@ tasks.withType(KotlinJvmCompile).configureEach { task ->
     apiVersion = KotlinVersion.KOTLIN_2_2
     languageVersion = KotlinVersion.KOTLIN_2_2
     jvmTarget = JvmTarget.JVM_17
-    freeCompilerArgs.add('-jvm-default=no-compatibility')
+    jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,17 +51,17 @@ dependencies {
 }
 
 tasks.withType(JavaCompile).configureEach { task ->
-  task.sourceCompatibility = '11'
-  task.targetCompatibility = '11'
+  task.sourceCompatibility = '17'
+  task.targetCompatibility = '17'
 }
 
 tasks.withType(KotlinJvmCompile).configureEach { task ->
   task.compilerOptions {
     // Ensure compatibility with old Gradle versions. Keep in sync with LicenseePlugin.kt.
-    apiVersion = KotlinVersion.KOTLIN_1_8
-    languageVersion = KotlinVersion.KOTLIN_1_8
-    jvmTarget = JvmTarget.JVM_11
-    freeCompilerArgs.add('-Xjvm-default=all')
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
+    jvmTarget = JvmTarget.JVM_17
+    freeCompilerArgs.add('-jvm-default=no-compatibility')
   }
 }
 

--- a/src/main/kotlin/app/cash/licensee/plugin.kt
+++ b/src/main/kotlin/app/cash/licensee/plugin.kt
@@ -40,8 +40,10 @@ class LicenseePlugin : Plugin<Project> {
   override fun apply(project: Project) {
     // HEY! If you update the minimum-supported Gradle version check to see if the Kotlin language version
     // can be bumped. See https://docs.gradle.org/current/userguide/compatibility.html#kotlin.
-    require(GradleVersion.current() >= GradleVersion.version("8.0")) {
-      "Licensee plugin requires Gradle 8.0 or later. Found ${GradleVersion.current()}"
+    val current = GradleVersion.current()
+    val required = GradleVersion.version("9.0")
+    require(current >= required) {
+      "Licensee plugin requires $required or later. Found $current"
     }
 
     val extension = project.objects.newInstance(MutableLicenseeExtension::class.java)


### PR DESCRIPTION
This allows us to use Kotlin 2.2 and Java 17. The forthcoming Kotlin 2.3.0 will no longer support compiling to 1.8, so we must bump.

Closes #494 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
