### PR TITLE
Use the GRADLE_PLUGIN_API_VERSION_ATTRIBUTE to set the required minim…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,22 @@ tasks.withType(JavaCompile).configureEach { task ->
 
 tasks.withType(KotlinJvmCompile).configureEach { task ->
   task.compilerOptions {
-    // Ensure compatibility with old Gradle versions. Keep in sync with LicenseePlugin.kt.
+    // Ensure compatibility with old Gradle versions. Keep in sync with the Gradle attribute.
     apiVersion = KotlinVersion.KOTLIN_2_2
     languageVersion = KotlinVersion.KOTLIN_2_2
     jvmTarget = JvmTarget.JVM_17
     jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+  }
+}
+
+// HEY! If you update the minimum-supported Gradle version check to see if the Kotlin language version
+// can be bumped. See https://docs.gradle.org/current/userguide/compatibility.html#kotlin.
+configurations.apiElements {
+  attributes {
+    attribute(
+      GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE,
+      objects.named(GradlePluginApiVersion, "9.0.0")
+    )
   }
 }
 

--- a/src/main/kotlin/app/cash/licensee/plugin.kt
+++ b/src/main/kotlin/app/cash/licensee/plugin.kt
@@ -26,7 +26,6 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
 import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
-import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.androidJvm
@@ -38,14 +37,6 @@ private const val REPORT_FOLDER = "licensee"
 @Suppress("unused") // Instantiated reflectively by Gradle.
 class LicenseePlugin : Plugin<Project> {
   override fun apply(project: Project) {
-    // HEY! If you update the minimum-supported Gradle version check to see if the Kotlin language version
-    // can be bumped. See https://docs.gradle.org/current/userguide/compatibility.html#kotlin.
-    val current = GradleVersion.current()
-    val required = GradleVersion.version("9.0")
-    require(current >= required) {
-      "Licensee plugin requires $required or later. Found $current"
-    }
-
     val extension = project.objects.newInstance(MutableLicenseeExtension::class.java)
     project.extensions.add(LicenseeExtension::class.java, "licensee", extension)
 


### PR DESCRIPTION
…um version of Gradle.

It available since 7.0, but Gradle 8.7 improved the error message: https://github.com/gradle/gradle/issues/24609

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
