### PR TITLE
Downgrade Poko and kotlinx-serialization to enable Kotlin metadata check

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ junit = "junit:junit:4.13.2"
 assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 testParameterInjector = "com.google.testparameterinjector:test-parameter-injector:1.19"
 
-kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
+kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1"
 
 maven-modelBuilder = "org.apache.maven:maven-model-builder:3.9.11"
 
@@ -32,5 +32,5 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 spotless = { id = "com.diffplug.spotless", version = "8.0.0" }
 publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
-poko = { id = "dev.drewhamilton.poko", version = "0.20.0" }
+poko = { id = "dev.drewhamilton.poko", version = "0.18.7" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.7.0" }

--- a/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
+++ b/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
@@ -358,8 +358,6 @@ class LicenseePluginFixtureTest(
     fixtureDir: File,
     vararg tasks: String = arrayOf("clean", "licensee"),
   ): GradleRunner {
-    val gradleRoot = File(fixtureDir, "gradle").also { it.mkdir() }
-    File("gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
     return GradleRunner.create()
       .apply {
         if (gradleVersion != LATEST_GRADLE_VERSION) {
@@ -368,7 +366,7 @@ class LicenseePluginFixtureTest(
       }
       .withProjectDir(fixtureDir)
       .withDebug(true) // Run in-process
-      .withArguments(*tasks, "--stacktrace", "--continue", "--configuration-cache", VERSION_PROPERTY)
+      .withArguments(*tasks, "--stacktrace", "--continue", "--configuration-cache", VERSION_PROPERTY, VALIDATE_KOTLIN_METADATA)
       .forwardOutput()
   }
 
@@ -393,6 +391,7 @@ class LicenseePluginFixtureTest(
 private val fixturesDir = File("src/test/fixtures")
 private const val VERSION_PROPERTY = "-PlicenseeVersion=$LICENSEE_VERSION"
 private const val LATEST_GRADLE_VERSION = "latest"
+private const val VALIDATE_KOTLIN_METADATA = "-Porg.gradle.kotlin.dsl.skipMetadataVersionCheck=false"
 
 /**
  * TODO: remove this after https://github.com/willowtreeapps/assertk/issues/515 is fixed.


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
