### PR TITLE
Remove outdated now default Dokka properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,8 +33,3 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-
-org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
-org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
-org.jetbrains.dokka.experimental.tryK2=true
-org.jetbrains.dokka.experimental.tryK2.nowarn=true


### PR DESCRIPTION
Manual work related to #507 

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
