### PR TITLE
Deprecate allowing dependencies using multi-string notations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Changed**
 
 - The minimum-supported Gradle version is now 9.0.
+- Deprecate allowing dependencies using multi-string notations.
 
 
 ## [1.14.1] - 2025-10-08

--- a/src/main/kotlin/app/cash/licensee/pluginExtension.kt
+++ b/src/main/kotlin/app/cash/licensee/pluginExtension.kt
@@ -108,6 +108,9 @@ interface LicenseeExtension {
    *
    * Reason strings will be included in validation reports.
    */
+  @Deprecated(
+    message = "Allowing dependencies using multi-string notation has been deprecated. Use the other overloads instead.",
+  )
   fun allowDependency(
     groupId: String,
     artifactId: String,
@@ -120,13 +123,13 @@ interface LicenseeExtension {
     options: Action<AllowDependencyOptions> = Action { },
   )
 
+  @Deprecated(
+    message = "Allowing dependencies using multi-string notation has been deprecated. Use the other overloads instead.",
+  )
   /** @suppress */
   @JvmSynthetic // For Groovy build scripts, hide from normal callers.
-  fun allowDependency(
-    groupId: String,
-    artifactId: String,
-    version: String,
-  ) {
+  fun allowDependency(groupId: String, artifactId: String, version: String) {
+    @Suppress("DEPRECATION") // Remove when we can break binary compatibility.
     allowDependency(groupId, artifactId, version, {})
   }
 
@@ -337,6 +340,7 @@ internal abstract class MutableLicenseeExtension : LicenseeExtension {
     allowedUrls.put(url, Optional.ofNullable(option.setReason))
   }
 
+  @Suppress("OVERRIDE_DEPRECATION") // Remove when we can break binary compatibility.
   override fun allowDependency(
     groupId: String,
     artifactId: String,


### PR DESCRIPTION
Refs https://docs.gradle.org/9.1.0/userguide/upgrading_version_9.html#dependency_multi_string_notation

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
