### PR TITLE
Eliminate redundant synthetic overloads in LicenseeExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@
 
 - The minimum-supported Gradle version is now 9.0.
 
-**Removed**
-
-- Eliminate redundant synthetic overloads in LicenseeExtension.
 
 ## [1.14.1] - 2025-10-08
 [1.14.1]: https://github.com/cashapp/licensee/releases/tag/1.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 - The minimum-supported Gradle version is now 9.0.
 
+**Removed**
+
+- Eliminate redundant synthetic overloads in LicenseeExtension.
 
 ## [1.14.1] - 2025-10-08
 [1.14.1]: https://github.com/cashapp/licensee/releases/tag/1.14.1

--- a/api/licensee.api
+++ b/api/licensee.api
@@ -54,22 +54,18 @@ public final class app/cash/licensee/ArtifactScm$Companion {
 public abstract interface class app/cash/licensee/LicenseeExtension {
 	public abstract fun allow (Lapp/cash/licensee/SpdxId;)V
 	public abstract fun allow (Ljava/lang/String;)V
-	public synthetic fun allowDependency (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun allowDependency (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun allowDependency (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public synthetic fun allowDependency (Lorg/gradle/api/provider/Provider;)V
+	public fun allowDependency (Lorg/gradle/api/provider/Provider;)V
 	public abstract fun allowDependency (Lorg/gradle/api/provider/Provider;Lorg/gradle/api/Action;)V
-	public static synthetic fun allowDependency$default (Lapp/cash/licensee/LicenseeExtension;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;ILjava/lang/Object;)V
-	public static synthetic fun allowDependency$default (Lapp/cash/licensee/LicenseeExtension;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/Action;ILjava/lang/Object;)V
-	public synthetic fun allowUrl (Ljava/lang/String;)V
+	public fun allowUrl (Ljava/lang/String;)V
 	public abstract fun allowUrl (Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public static synthetic fun allowUrl$default (Lapp/cash/licensee/LicenseeExtension;Ljava/lang/String;Lorg/gradle/api/Action;ILjava/lang/Object;)V
 	public abstract fun getAndroidAssetReportPath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBundleAndroidAsset ()Lorg/gradle/api/provider/Property;
-	public synthetic fun ignoreDependencies (Ljava/lang/String;)V
-	public synthetic fun ignoreDependencies (Ljava/lang/String;Ljava/lang/String;)V
+	public fun ignoreDependencies (Ljava/lang/String;)V
+	public fun ignoreDependencies (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun ignoreDependencies (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public synthetic fun ignoreDependencies (Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public static synthetic fun ignoreDependencies$default (Lapp/cash/licensee/LicenseeExtension;Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;ILjava/lang/Object;)V
+	public fun ignoreDependencies (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun unusedAction (Lapp/cash/licensee/UnusedAction;)V
 	public abstract fun violationAction (Lapp/cash/licensee/ViolationAction;)V
 }

--- a/src/main/kotlin/app/cash/licensee/pluginExtension.kt
+++ b/src/main/kotlin/app/cash/licensee/pluginExtension.kt
@@ -80,11 +80,9 @@ interface LicenseeExtension {
    * }
    * ```
    */
-  fun allowUrl(url: String, options: Action<AllowUrlOptions> = Action {})
+  fun allowUrl(url: String, options: Action<AllowUrlOptions>)
 
-  /** @suppress */
-  @JvmSynthetic // For Groovy build scripts, hide from normal callers.
-  fun allowUrl(url: String) = allowUrl(url, {})
+  fun allowUrl(url: String) = allowUrl(url = url, options = {})
 
   /**
    * Allow an artifact with a specific groupId, artifactId, and version. This is useful for
@@ -113,24 +111,20 @@ interface LicenseeExtension {
     groupId: String,
     artifactId: String,
     version: String,
-    options: Action<AllowDependencyOptions> = Action {},
+    options: Action<AllowDependencyOptions>,
   )
 
   fun allowDependency(
     dependencyProvider: Provider<out Dependency>,
-    options: Action<AllowDependencyOptions> = Action {},
+    options: Action<AllowDependencyOptions>,
   )
 
-  /** @suppress */
-  @JvmSynthetic // For Groovy build scripts, hide from normal callers.
   fun allowDependency(groupId: String, artifactId: String, version: String) {
-    allowDependency(groupId, artifactId, version, {})
+    allowDependency(groupId = groupId, artifactId = artifactId, version = version, options = {})
   }
 
-  /** @suppress */
-  @JvmSynthetic // For Groovy build scripts, hide from normal callers.
   fun allowDependency(dependencyProvider: Provider<out Dependency>) {
-    allowDependency(dependencyProvider, {})
+    allowDependency(dependencyProvider = dependencyProvider, options = {})
   }
 
   /**
@@ -175,26 +169,20 @@ interface LicenseeExtension {
    */
   fun ignoreDependencies(
     groupId: String,
-    artifactId: String? = null,
-    options: Action<IgnoreDependencyOptions> = Action {},
+    artifactId: String?,
+    options: Action<IgnoreDependencyOptions>,
   )
 
-  /** @suppress */
-  @JvmSynthetic // For Groovy build scripts, hide from normal callers.
   fun ignoreDependencies(groupId: String) {
-    ignoreDependencies(groupId, options = {})
+    ignoreDependencies(groupId = groupId, artifactId = null, options = {})
   }
 
-  /** @suppress */
-  @JvmSynthetic // For Groovy build scripts, hide from normal callers.
   fun ignoreDependencies(groupId: String, options: Action<IgnoreDependencyOptions>) {
     ignoreDependencies(groupId = groupId, artifactId = null, options = options)
   }
 
-  /** @suppress */
-  @JvmSynthetic // For Groovy build scripts, hide from normal callers.
   fun ignoreDependencies(groupId: String, artifactId: String) {
-    ignoreDependencies(groupId, artifactId, {})
+    ignoreDependencies(groupId = groupId, artifactId = artifactId, options = {})
   }
 
   /**


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
