### PR TITLE
Add fallback url for MIT

### DIFF
--- a/gradle/build-logic/src/main/kotlin/app/cash/licensee/defaultFallbackUrls.kt
+++ b/gradle/build-logic/src/main/kotlin/app/cash/licensee/defaultFallbackUrls.kt
@@ -44,6 +44,7 @@ internal val defaultFallbackUrls: FallbackBuilder.() -> Unit = {
   putLicense("MIT") {
     add("http://opensource.org/licenses/mit-license")
     add("https://opensource.org/licenses/mit-license")
+    add("https://opensource.org/license/mit")
     add("http://www.opensource.org/licenses/mit-license.php")
     add("https://www.opensource.org/licenses/mit-license.php")
     add("http://api.github.com/licenses/mit")


### PR DESCRIPTION
Coming from:

```
org.slf4j:slf4j-api:2.0.17
 - ERROR: Unknown license URL 'https://opensource.org/license/mit' is NOT allowed
 ```