### PR TITLE
Replace usage of deprecated lenient configuration with Artifact view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Minify the JSON file bundled under APK asset.
 - Remove support for the `org.jetbrains.kotlin.js` plugin.
 
+**Fixed**
+
+- Replace to-be-deprecated `lenientConfiguration` with `ArtifactView` API instead. Fixes ([#607](https://github.com/cashapp/licensee/issues/607)).
+
 
 ## [1.14.1] - 2025-10-08
 [1.14.1]: https://github.com/cashapp/licensee/releases/tag/1.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 **Fixed**
 
-- Replace to-be-deprecated `lenientConfiguration` with `ArtifactView` API instead. Fixes ([#607](https://github.com/cashapp/licensee/issues/607)).
+- Replace usage of Gradle's to-be-deprecated `lenientConfiguration` API with `ArtifactView`.
 
 
 ## [1.14.1] - 2025-10-08

--- a/src/main/kotlin/app/cash/licensee/task.kt
+++ b/src/main/kotlin/app/cash/licensee/task.kt
@@ -33,6 +33,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.attributes.Attribute
@@ -181,10 +182,8 @@ abstract class LicenseeTask : DefaultTask() {
       .distinctBy { it.dependencyCoordinates }
   }
 
-  private fun Configuration.artifacts() =
-    resolvedConfiguration.lenientConfiguration.allModuleDependencies.flatMap {
-      it.allModuleArtifacts
-    }
+  private fun Configuration.artifacts(): Set<ResolvedArtifactResult> =
+    incoming.artifactView { it.isLenient = true }.artifacts.artifacts
 
   @get:OutputDirectory abstract val outputDir: DirectoryProperty
 


### PR DESCRIPTION
Fixes https://github.com/cashapp/licensee/issues/607

For me some tests are failing locally with OOM, but that happens on trunk as well. If I remove `.withDebug(true) // Run in-process` from the test and give the process more RAM by adding `build/tmp/test/work/.gradle-test-kit/gradle.properties` with `org.gradle.jvmargs=-Xmx16g -Dfile.encoding=UTF-8` the tests pass on both trunk and this branch

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
